### PR TITLE
Fix failing Docker Compose services on Windows-based build agents

### DIFF
--- a/Build/RunComposeServices.ps1
+++ b/Build/RunComposeServices.ps1
@@ -32,7 +32,7 @@ Param(
 
     # An optional dictionary storing variables which will be passed to the containers started via Docker Compose.
     [hashtable]
-    $ExtraEnvironmentVariables
+    $EnvironmentVariables
 )
 
 Write-Output "Preparing to start compose services from project: $ComposeProjectName"
@@ -55,9 +55,9 @@ if (![System.IO.File]::Exists($ComposeEnvironmentFilePath))
     exit 2;
 }
 
-if ($ExtraEnvironmentVariables -ne $null)
+if ($EnvironmentVariables -ne $null)
 {
-    $ExtraEnvironmentVariables.GetEnumerator() | ForEach-Object {
+    $EnvironmentVariables.GetEnumerator() | ForEach-Object {
         [System.Environment]::SetEnvironmentVariable($_.Key, $_.Value, 'Process')
     }
 }

--- a/Build/RunComposeServices.ps1
+++ b/Build/RunComposeServices.ps1
@@ -55,27 +55,6 @@ if (![System.IO.File]::Exists($ComposeEnvironmentFilePath))
     exit 2;
 }
 
-$EnvironmentFileLines = Get-Content -Path $ComposeEnvironmentFilePath
-
-foreach ($EnvironmentFileLine in $EnvironmentFileLines)
-{
-    if(($EnvironmentFileLine.Trim().Length -eq 0) -or ($EnvironmentFileLine.StartsWith('#')))
-    {
-        # Ignore empty lines and those representing comments
-        continue;
-    }
-    
-    # Each line of text will be split using first delimiter only
-    $EnvironmentFileLineParts = $EnvironmentFileLine.Split('=', 2)
-    $EnvironmentVariableName = $EnvironmentFileLineParts[0]
-    $EnvironmentVariableValue = $EnvironmentFileLineParts[1]
-
-    # Each key-value pair from the environment file will be promoted to an environment variable
-    # in the scope of the current process since, AFAIK, there's no other way of passing such variables
-    # to the containers started by Docker Compose
-    [System.Environment]::SetEnvironmentVariable($EnvironmentVariableName, $EnvironmentVariableValue, 'Process')
-}
-
 if ($ExtraEnvironmentVariables -ne $null)
 {
     $ExtraEnvironmentVariables.GetEnumerator() | ForEach-Object {

--- a/Build/RunComposeServices.ps1
+++ b/Build/RunComposeServices.ps1
@@ -92,6 +92,7 @@ Write-Output $InfoMessage
 # standard error stream, thus tricking runtime into thinking it has failed.
 docker-compose --file="$ComposeFilePath" `
                --project-name="$ComposeProjectName" `
+               --env-file="$RelativePathToEnvironmentFile" `
                up `
                --detach
 

--- a/Build/RunComposeServices.ps1
+++ b/Build/RunComposeServices.ps1
@@ -92,7 +92,7 @@ Write-Output $InfoMessage
 # standard error stream, thus tricking runtime into thinking it has failed.
 docker-compose --file="$ComposeFilePath" `
                --project-name="$ComposeProjectName" `
-               --env-file="$RelativePathToEnvironmentFile" `
+               --env-file="$ComposeEnvironmentFilePath" `
                up `
                --detach
 

--- a/Build/RunComposeServices.ps1
+++ b/Build/RunComposeServices.ps1
@@ -37,7 +37,7 @@ Param(
 
 Write-Output "Preparing to start compose services from project: $ComposeProjectName"
 Write-Output "Current script path is: $PSScriptRoot"
-$ComposeFilePath = Join-Path -Path $PSScriptRoot $RelativePathToComposeFile
+$ComposeFilePath = [System.IO.Path]::GetFullPath((Join-Path -Path $PSScriptRoot $RelativePathToComposeFile))
 
 if (![System.IO.File]::Exists($ComposeFilePath))
 {
@@ -46,7 +46,7 @@ if (![System.IO.File]::Exists($ComposeFilePath))
     exit 1;
 }
 
-$ComposeEnvironmentFilePath = Join-Path -Path $PSScriptRoot $RelativePathToEnvironmentFile
+$ComposeEnvironmentFilePath = [System.IO.Path]::GetFullPath((Join-Path -Path $PSScriptRoot $RelativePathToEnvironmentFile))
 
 if (![System.IO.File]::Exists($ComposeEnvironmentFilePath))
 {

--- a/Build/SonarBuildBreaker.ps1
+++ b/Build/SonarBuildBreaker.ps1
@@ -59,8 +59,6 @@ $Response = Invoke-WebRequest -Uri $SonarWebApiUrl `
                               -ErrorAction Stop `
                               | ConvertFrom-Json
 
-Write-Output -InputObject $Response
-
 if ($Response.projectStatus.status -eq 'OK')
 {
     Write-Output "Quality gate PASSED. Please check it here: $SonarDashboardUrl"

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -235,7 +235,7 @@ jobs:
         -ComposeProjectName '${{ parameters.integrationTests.composeProjectName }}' `
         -RelativePathToComposeFile './db4it-compose/docker-compose.yml' `
         -RelativePathToEnvironmentFile './db4it-compose/.env' `
-        -ExtraEnvironmentVariables `
+        -EnvironmentVariables `
          @{ `
            'db_docker_image'='${{ parameters.integrationTests.databaseDockerImage }}'; `
            'db_name'='${{ parameters.integrationTests.databaseName }}'; `

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -5,6 +5,7 @@ parameters:
   pool: ''
   build:
     configuration: 'Release'
+  installDotNetSdk: True
   # Since currently downloading an archive containing a cache of restored 
   # NuGet packages takes considerably more time than just doing a restore 
   # with each build, this feature has been turned off.
@@ -64,6 +65,7 @@ jobs:
   - task: UseDotNet@2
     name: 'install_dotnetcore_sdk_required_by_application'
     displayName: 'Install .NET Core SDK required by application'
+    condition: eq(${{ parameters.installDotNetSdk }}, True)
     inputs:
       packageType: 'sdk'
       version: $(DotNetCore_SDK_Version)

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -5,7 +5,7 @@ parameters:
   pool: ''
   build:
     configuration: 'Release'
-  installDotNetSdk: True
+  installDotNetSdk: False
   # Since currently downloading an archive containing a cache of restored 
   # NuGet packages takes considerably more time than just doing a restore 
   # with each build, this feature has been turned off.

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -5,7 +5,7 @@ parameters:
   pool: ''
   build:
     configuration: 'Release'
-  installDotNetSdk: False
+  installDotNetSdk: True
   # Since currently downloading an archive containing a cache of restored 
   # NuGet packages takes considerably more time than just doing a restore 
   # with each build, this feature has been turned off.

--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -90,20 +90,20 @@ jobs:
       databaseDockerImage: 'postgres:12-alpine'
       composeProjectName: 'integration-test-prerequisites'
       
-#- template: './azure-pipelines.job-template.yml'
-#  parameters:
-#    job:
-#      name: 'macOS'
-#      displayName: 'Run on macOS'
-#    pool:
-#      vmImage: 'macOS-10.15'
-#    integrationTests:
-#      databaseHost: 'localhost'
-#      databaseName: '$(IntegrationTests.Database.Todo.Name)'
-#      databaseUsername: '$(IntegrationTests.Database.Todo.Username)'
-#      databasePassword: '$(IntegrationTests.Database.Todo.Password)'
-#      databaseDockerImage: 'postgres:12-alpine'
-#      composeProjectName: 'integration-test-prerequisites'
+- template: './azure-pipelines.job-template.yml'
+  parameters:
+    job:
+      name: 'macOS'
+      displayName: 'Run on macOS'
+    pool:
+      vmImage: 'macOS-10.15'
+    integrationTests:
+      databaseHost: 'localhost'
+      databaseName: '$(IntegrationTests.Database.Todo.Name)'
+      databaseUsername: '$(IntegrationTests.Database.Todo.Username)'
+      databasePassword: '$(IntegrationTests.Database.Todo.Password)'
+      databaseDockerImage: 'postgres:12-alpine'
+      composeProjectName: 'integration-test-prerequisites'
       
 - template: './azure-pipelines.job-template.yml'
   parameters:

--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -45,7 +45,7 @@ variables:
   # Specifies the version of the .NET Core SDK to install and use when running this pipeline.
   # All releases can be found here: https://dotnet.microsoft.com/download/dotnet-core.
   - name: 'DotNetCore_SDK_Version'
-    value: '3.1.302'
+    value: '3.1.407'
 
   # Specifies the version of the ReportGenerator tool used for generating code coverage reports.
   # All releases can be found here: https://github.com/danielpalme/ReportGenerator/releases.

--- a/Build/azure-pipelines.yml
+++ b/Build/azure-pipelines.yml
@@ -90,20 +90,20 @@ jobs:
       databaseDockerImage: 'postgres:12-alpine'
       composeProjectName: 'integration-test-prerequisites'
       
-- template: './azure-pipelines.job-template.yml'
-  parameters:
-    job:
-      name: 'macOS'
-      displayName: 'Run on macOS'
-    pool:
-      vmImage: 'macOS-10.15'
-    integrationTests:
-      databaseHost: 'localhost'
-      databaseName: '$(IntegrationTests.Database.Todo.Name)'
-      databaseUsername: '$(IntegrationTests.Database.Todo.Username)'
-      databasePassword: '$(IntegrationTests.Database.Todo.Password)'
-      databaseDockerImage: 'postgres:12-alpine'
-      composeProjectName: 'integration-test-prerequisites'
+#- template: './azure-pipelines.job-template.yml'
+#  parameters:
+#    job:
+#      name: 'macOS'
+#      displayName: 'Run on macOS'
+#    pool:
+#      vmImage: 'macOS-10.15'
+#    integrationTests:
+#      databaseHost: 'localhost'
+#      databaseName: '$(IntegrationTests.Database.Todo.Name)'
+#      databaseUsername: '$(IntegrationTests.Database.Todo.Username)'
+#      databasePassword: '$(IntegrationTests.Database.Todo.Password)'
+#      databaseDockerImage: 'postgres:12-alpine'
+#      composeProjectName: 'integration-test-prerequisites'
       
 - template: './azure-pipelines.job-template.yml'
   parameters:

--- a/Build/db4it-compose/.env
+++ b/Build/db4it-compose/.env
@@ -1,8 +1,3 @@
-db_docker_image=<USE_EITHER_LINUX_OR_WINDOWS_DOCKER_IMAGE>
-db_name=aspnet-core-logging-it
-db_username=<DO_NOT_STORE_SENSITIVE_DATA_HERE>
-db_password=<DO_NOT_STORE_SENSITIVE_DATA_HERE>
-
 # See more about heathchecks in Docker Compose here: 
 # https://docs.docker.com/compose/compose-file/#healthcheck.
 db_healthcheck_interval=2s


### PR DESCRIPTION
This fix takes care of the following error occurring on Azure DevOps Windows-based build agents:
_no such image: <USE_EITHER_LINUX_OR_WINDOWS_DOCKER_IMAGE>: invalid reference format: repository name must be lowercase
##[error]Failed to identify compose services for project: integration-test-prerequisites_