### PR TITLE
Update OpenTelemetry and SonarAnalyzer.CSharp NuGet packages to their latest versions

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -34,10 +34,10 @@
         <PackageReference Update="NUnit" Version="3.13.3"/>
         <PackageReference Update="NUnit3TestAdapter" Version="4.3.1"/>
         <PackageReference Update="NunitXml.TestLogger" Version="3.0.127"/>
-        <PackageReference Update="OpenTelemetry" Version="1.3.1" />
+        <PackageReference Update="OpenTelemetry" Version="1.3.2" />
         <PackageReference Update="OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta2" />
         <PackageReference Update="OpenTelemetry.Contrib.Preview" Version="1.0.0-beta2" />
-        <PackageReference Update="OpenTelemetry.Exporter.Jaeger" Version="1.3.1" />
+        <PackageReference Update="OpenTelemetry.Exporter.Jaeger" Version="1.3.2" />
         <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.1" />
         <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.1" />
         <PackageReference Update="Serilog.AspNetCore" Version="6.1.0"/>
@@ -50,7 +50,7 @@
             Use 'Include' XML attribute instead of 'Update' since this reference will be added to all projects affected
             by this .targets file, more specifically, all projects found in this solution!
         -->
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.50.0.58025">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -34,12 +34,12 @@
         <PackageReference Update="NUnit" Version="3.13.3"/>
         <PackageReference Update="NUnit3TestAdapter" Version="4.3.1"/>
         <PackageReference Update="NunitXml.TestLogger" Version="3.0.127"/>
-        <PackageReference Update="OpenTelemetry" Version="1.3.2" />
+        <PackageReference Update="OpenTelemetry" Version="1.4.0-beta.2" />
         <PackageReference Update="OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore" Version="1.0.0-beta2" />
-        <PackageReference Update="OpenTelemetry.Contrib.Preview" Version="1.0.0-beta2" />
-        <PackageReference Update="OpenTelemetry.Exporter.Jaeger" Version="1.3.2" />
-        <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.1" />
-        <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.1" />
+        <PackageReference Update="OpenTelemetry.Exporter.Jaeger" Version="1.4.0-beta.2" />
+        <PackageReference Update="OpenTelemetry.Extensions" Version="1.0.0-beta.3" />
+        <PackageReference Update="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.8" />
+        <PackageReference Update="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.8" />
         <PackageReference Update="Serilog.AspNetCore" Version="6.1.0"/>
         <PackageReference Update="Serilog.Enrichers.Span" Version="3.0.0" />
         <PackageReference Update="Serilog.Enrichers.Thread" Version="3.1.0"/>

--- a/Sources/Todo.ApplicationFlows/packages.lock.json
+++ b/Sources/Todo.ApplicationFlows/packages.lock.json
@@ -4,9 +4,9 @@
     "net7.0": {
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",

--- a/Sources/Todo.Commons/packages.lock.json
+++ b/Sources/Todo.Commons/packages.lock.json
@@ -30,9 +30,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",

--- a/Sources/Todo.Persistence/packages.lock.json
+++ b/Sources/Todo.Persistence/packages.lock.json
@@ -25,9 +25,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",

--- a/Sources/Todo.Services/packages.lock.json
+++ b/Sources/Todo.Services/packages.lock.json
@@ -4,9 +4,9 @@
     "net7.0": {
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "System.IdentityModel.Tokens.Jwt": {
         "type": "Direct",

--- a/Sources/Todo.Telemetry/OpenTelemetry/OpenTelemetryActivator.cs
+++ b/Sources/Todo.Telemetry/OpenTelemetry/OpenTelemetryActivator.cs
@@ -102,8 +102,7 @@ namespace Todo.Telemetry.OpenTelemetry
             {
                 if (openTelemetryOptions.AttachLogsToActivity)
                 {
-                    // Ensure events produces by ILogger will be exported by Open Telemetry to Jaeger.
-                    // See more here: https://github.com/open-telemetry/opentelemetry-dotnet/issues/1739.
+                    // Ensure events produces by ILogger will be exported by Open Telemetry to the configured exporter back-end (i.e., Jaeger).
                     options.AttachLogsToActivityEvent();
                 }
 

--- a/Sources/Todo.Telemetry/Todo.Telemetry.csproj
+++ b/Sources/Todo.Telemetry/Todo.Telemetry.csproj
@@ -17,8 +17,8 @@
     <ItemGroup>
         <PackageReference Include="OpenTelemetry" />
         <PackageReference Include="OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore" />
-        <PackageReference Include="OpenTelemetry.Contrib.Preview" />
         <PackageReference Include="OpenTelemetry.Exporter.Jaeger" />
+        <PackageReference Include="OpenTelemetry.Extensions" />
         <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
         <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
         <PackageReference Include="Serilog.AspNetCore" />

--- a/Sources/Todo.Telemetry/packages.lock.json
+++ b/Sources/Todo.Telemetry/packages.lock.json
@@ -4,13 +4,13 @@
     "net7.0": {
       "OpenTelemetry": {
         "type": "Direct",
-        "requested": "[1.3.1, )",
-        "resolved": "1.3.1",
-        "contentHash": "PWIl/juBJBFi4Adx07nltkxA2ZCwutd2A+KAvO3TOYV+xeIiN6afT5bE4W3EebqdDV0T3buq/vAlQ2ZDC9zYew==",
+        "requested": "[1.3.2, )",
+        "resolved": "1.3.2",
+        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.1",
+          "OpenTelemetry.Api": "1.3.2",
           "System.Collections.Immutable": "1.4.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
@@ -35,11 +35,11 @@
       },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Direct",
-        "requested": "[1.3.1, )",
-        "resolved": "1.3.1",
-        "contentHash": "+JJyvuKDBn4PqY1vH8b3bneniEizakCVstddZxkiTiVMO5+vJDZg2qLCDrfZIZYpv/SKcVty/qLTR2Qhb3Opxw==",
+        "requested": "[1.3.2, )",
+        "resolved": "1.3.2",
+        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.1",
+          "OpenTelemetry": "1.3.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
         }
       },
@@ -122,9 +122,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",
@@ -367,8 +367,8 @@
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "p4ufCQ+afYMEYh1pF8K5huhJ4PnYVvKvje+GjhiDPRrQTmwto5nl8spjeK9N1OXg2HFmGuMXQvc8y90RoNLekg==",
+        "resolved": "1.3.2",
+        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
           "System.Reflection.Emit.Lightweight": "4.7.0"

--- a/Sources/Todo.Telemetry/packages.lock.json
+++ b/Sources/Todo.Telemetry/packages.lock.json
@@ -4,15 +4,15 @@
     "net7.0": {
       "OpenTelemetry": {
         "type": "Direct",
-        "requested": "[1.3.2, )",
-        "resolved": "1.3.2",
-        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
+        "requested": "[1.4.0-beta.2, )",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "GuCTKn2pLtTzhP7GY6Y5M+DmuGQLfZL07xty8nX+/p5u0637+X2H1EJuE2p5hC18GgfMcV1y5O/haMcAN3a28Q==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.1.0",
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.2",
-          "System.Collections.Immutable": "1.4.0",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "Microsoft.Extensions.Options": "5.0.0",
+          "OpenTelemetry.Api": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": {
@@ -24,42 +24,42 @@
           "OpenTelemetry.Api": "1.0.1"
         }
       },
-      "OpenTelemetry.Contrib.Preview": {
-        "type": "Direct",
-        "requested": "[1.0.0-beta2, )",
-        "resolved": "1.0.0-beta2",
-        "contentHash": "febtaMVJAMZ2+EHntqvMXvcsMEkA5F5FXKwODz9LM0UjJ5gfNTqjY36YTddPASEZBn0a6YLRqovRW1QnMJ46NQ==",
-        "dependencies": {
-          "OpenTelemetry": "1.1.0-beta3"
-        }
-      },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Direct",
-        "requested": "[1.3.2, )",
-        "resolved": "1.3.2",
-        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
+        "requested": "[1.4.0-beta.2, )",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "xvW5FhG9UcYdVdd6yRHpRXbg1RpS4eEGi8zQGc8PWpsbXiv4pRiiuXxpu5niLKsGU0OVkExhobQgFMKiPOwPzw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.2",
+          "OpenTelemetry": "1.4.0-beta.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
+        }
+      },
+      "OpenTelemetry.Extensions": {
+        "type": "Direct",
+        "requested": "[1.0.0-beta.3, )",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "XJoH2cyClDFJTCZPlNlsfq+si6f1HWdSHcVZyXQmQhw5w+DxXccKbLRRBo7Dn/l3brMIRna+1ZAXc68Y6SMCfA==",
+        "dependencies": {
+          "OpenTelemetry": "[1.4.0-beta.2]"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "Direct",
-        "requested": "[1.0.0-rc9.1, )",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "AlodOzqLW+/FOB0fdlhVfk7r6/wkNFgVr/eitugdPE9IEI3WU1PT8VYDPVE2M+Xyof8+k2pjvQKn6IejrybYUQ==",
+        "requested": "[1.0.0-rc9.8, )",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "pnUHhcF86azvEQ9sjccvwP5o606TY8m0hngP11jn9Jfg6k4fPCbh5+p5Uqbv2MCgZyecWw5YIa/zoz3OA7MNbQ==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "2.1.0",
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Direct",
-        "requested": "[1.0.0-rc9.1, )",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "//6Qy9iMjpA9JiGmX9xx2GQUB/WL3Fr4Z21naWdTQuhpc+4uLOxQDWCD1rfDZHi6S8S4HluatNZISZ4Mow+YNg==",
+        "requested": "[1.0.0-rc9.8, )",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "Os0mT2ogoKBbK8z6c0lDJ/sCOq6vfR3F8pYfOFA9Hn26YMqVsfO5JO2JKzOdaOOmAFACDkv2VI4qiPVvKKqUUA==",
         "dependencies": {
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "Serilog.AspNetCore": {
@@ -198,6 +198,14 @@
           "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "Lu41BWNmwhKr6LgyQvcYBOge0pPvmiaK8R5UHXX4//wBhonJyWcT2OK1mqYfEM5G7pTf31fPrpIHOT6sN7EGOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -212,6 +220,14 @@
         "contentHash": "vAuFMOvK68JIW0NlLp1mJkQxsJ2hGmLKRE2rOyIffZ/L0Xvr6hsPMF8thxPGTcgOM6eezisSTTVVHdByY6ejbQ==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "WryksPlAFFRMWIGpFwDDbrVSD/kSO7P7fRRzBHh6vEIrgflsM8tpPCcgIvKszH4fz4vcuapih9RMdiiJ2VS7aw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "3.1.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -367,11 +383,10 @@
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "QnMZOFX9xj7aHaAK8f81wMV6yzW7Ba3DtPFcLhqrmg9g00eXRrE/RCvZp6PemZCnISKY2q5O2y/rmSKzvTMlpA==",
         "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "System.Diagnostics.DiagnosticSource": "7.0.0-rc.1.22426.10"
         }
       },
       "Serilog": {
@@ -450,11 +465,6 @@
           "Serilog": "2.0.0"
         }
       },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "71hw5RUJRu5+q/geUY69gpXD8Upd12cH+F3MwpXV2zle7Bqqkrmc1JblOTuvUcgmdnUtQvBlV5e1d6RH+H2lvA=="
-      },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -468,11 +478,6 @@
           "Microsoft.IdentityModel.JsonWebTokens": "6.25.1",
           "Microsoft.IdentityModel.Tokens": "6.25.1"
         }
-      },
-      "System.Reflection.Emit.Lightweight": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Runtime": {
         "type": "Transitive",

--- a/Sources/Todo.WebApi/packages.lock.json
+++ b/Sources/Todo.WebApi/packages.lock.json
@@ -35,9 +35,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",
@@ -312,20 +312,20 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "PWIl/juBJBFi4Adx07nltkxA2ZCwutd2A+KAvO3TOYV+xeIiN6afT5bE4W3EebqdDV0T3buq/vAlQ2ZDC9zYew==",
+        "resolved": "1.3.2",
+        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.1",
+          "OpenTelemetry.Api": "1.3.2",
           "System.Collections.Immutable": "1.4.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "p4ufCQ+afYMEYh1pF8K5huhJ4PnYVvKvje+GjhiDPRrQTmwto5nl8spjeK9N1OXg2HFmGuMXQvc8y90RoNLekg==",
+        "resolved": "1.3.2",
+        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -349,10 +349,10 @@
       },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "+JJyvuKDBn4PqY1vH8b3bneniEizakCVstddZxkiTiVMO5+vJDZg2qLCDrfZIZYpv/SKcVty/qLTR2Qhb3Opxw==",
+        "resolved": "1.3.2",
+        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.1",
+          "OpenTelemetry": "1.3.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
         }
       },
@@ -606,10 +606,10 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.1, )",
+          "OpenTelemetry": "[1.3.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
           "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
           "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
           "Serilog.AspNetCore": "[6.1.0, )",

--- a/Sources/Todo.WebApi/packages.lock.json
+++ b/Sources/Todo.WebApi/packages.lock.json
@@ -116,6 +116,14 @@
           "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "Lu41BWNmwhKr6LgyQvcYBOge0pPvmiaK8R5UHXX4//wBhonJyWcT2OK1mqYfEM5G7pTf31fPrpIHOT6sN7EGOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -130,6 +138,14 @@
         "contentHash": "vAuFMOvK68JIW0NlLp1mJkQxsJ2hGmLKRE2rOyIffZ/L0Xvr6hsPMF8thxPGTcgOM6eezisSTTVVHdByY6ejbQ==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "WryksPlAFFRMWIGpFwDDbrVSD/kSO7P7fRRzBHh6vEIrgflsM8tpPCcgIvKszH4fz4vcuapih9RMdiiJ2VS7aw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "3.1.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -312,23 +328,22 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "GuCTKn2pLtTzhP7GY6Y5M+DmuGQLfZL07xty8nX+/p5u0637+X2H1EJuE2p5hC18GgfMcV1y5O/haMcAN3a28Q==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.1.0",
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.2",
-          "System.Collections.Immutable": "1.4.0",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "Microsoft.Extensions.Options": "5.0.0",
+          "OpenTelemetry.Api": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "QnMZOFX9xj7aHaAK8f81wMV6yzW7Ba3DtPFcLhqrmg9g00eXRrE/RCvZp6PemZCnISKY2q5O2y/rmSKzvTMlpA==",
         "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "System.Diagnostics.DiagnosticSource": "7.0.0-rc.1.22426.10"
         }
       },
       "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": {
@@ -339,38 +354,38 @@
           "OpenTelemetry.Api": "1.0.1"
         }
       },
-      "OpenTelemetry.Contrib.Preview": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta2",
-        "contentHash": "febtaMVJAMZ2+EHntqvMXvcsMEkA5F5FXKwODz9LM0UjJ5gfNTqjY36YTddPASEZBn0a6YLRqovRW1QnMJ46NQ==",
-        "dependencies": {
-          "OpenTelemetry": "1.1.0-beta3"
-        }
-      },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "xvW5FhG9UcYdVdd6yRHpRXbg1RpS4eEGi8zQGc8PWpsbXiv4pRiiuXxpu5niLKsGU0OVkExhobQgFMKiPOwPzw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.2",
+          "OpenTelemetry": "1.4.0-beta.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
+        }
+      },
+      "OpenTelemetry.Extensions": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "XJoH2cyClDFJTCZPlNlsfq+si6f1HWdSHcVZyXQmQhw5w+DxXccKbLRRBo7Dn/l3brMIRna+1ZAXc68Y6SMCfA==",
+        "dependencies": {
+          "OpenTelemetry": "[1.4.0-beta.2]"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "AlodOzqLW+/FOB0fdlhVfk7r6/wkNFgVr/eitugdPE9IEI3WU1PT8VYDPVE2M+Xyof8+k2pjvQKn6IejrybYUQ==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "pnUHhcF86azvEQ9sjccvwP5o606TY8m0hngP11jn9Jfg6k4fPCbh5+p5Uqbv2MCgZyecWw5YIa/zoz3OA7MNbQ==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "2.1.0",
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "//6Qy9iMjpA9JiGmX9xx2GQUB/WL3Fr4Z21naWdTQuhpc+4uLOxQDWCD1rfDZHi6S8S4HluatNZISZ4Mow+YNg==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "Os0mT2ogoKBbK8z6c0lDJ/sCOq6vfR3F8pYfOFA9Hn26YMqVsfO5JO2JKzOdaOOmAFACDkv2VI4qiPVvKKqUUA==",
         "dependencies": {
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "Serilog": {
@@ -507,11 +522,6 @@
         "resolved": "4.4.0",
         "contentHash": "2sCCb7doXEwtYAbqzbF/8UAeDRMNmPaQbU2q50Psg1J9KzumyVVCgKQY8s53WIPTufNT0DpSe9QRvVjOzfDWBA=="
       },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "71hw5RUJRu5+q/geUY69gpXD8Upd12cH+F3MwpXV2zle7Bqqkrmc1JblOTuvUcgmdnUtQvBlV5e1d6RH+H2lvA=="
-      },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -525,11 +535,6 @@
           "Microsoft.IdentityModel.JsonWebTokens": "6.25.1",
           "Microsoft.IdentityModel.Tokens": "6.25.1"
         }
-      },
-      "System.Reflection.Emit.Lightweight": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Runtime": {
         "type": "Transitive",
@@ -606,12 +611,12 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.2, )",
+          "OpenTelemetry": "[1.4.0-beta.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
-          "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
-          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.4.0-beta.2, )",
+          "OpenTelemetry.Extensions": "[1.0.0-beta.3, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.8, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.8, )",
           "Serilog.AspNetCore": "[6.1.0, )",
           "Serilog.Enrichers.Span": "[3.0.0, )",
           "Serilog.Enrichers.Thread": "[3.1.0, )",

--- a/Tests/ArchitectureTests/Todo.ArchitectureTests/packages.lock.json
+++ b/Tests/ArchitectureTests/Todo.ArchitectureTests/packages.lock.json
@@ -53,9 +53,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",
@@ -379,20 +379,20 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "PWIl/juBJBFi4Adx07nltkxA2ZCwutd2A+KAvO3TOYV+xeIiN6afT5bE4W3EebqdDV0T3buq/vAlQ2ZDC9zYew==",
+        "resolved": "1.3.2",
+        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.1",
+          "OpenTelemetry.Api": "1.3.2",
           "System.Collections.Immutable": "1.4.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "p4ufCQ+afYMEYh1pF8K5huhJ4PnYVvKvje+GjhiDPRrQTmwto5nl8spjeK9N1OXg2HFmGuMXQvc8y90RoNLekg==",
+        "resolved": "1.3.2",
+        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -416,10 +416,10 @@
       },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "+JJyvuKDBn4PqY1vH8b3bneniEizakCVstddZxkiTiVMO5+vJDZg2qLCDrfZIZYpv/SKcVty/qLTR2Qhb3Opxw==",
+        "resolved": "1.3.2",
+        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.1",
+          "OpenTelemetry": "1.3.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
         }
       },
@@ -678,10 +678,10 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.1, )",
+          "OpenTelemetry": "[1.3.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
           "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
           "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
           "Serilog.AspNetCore": "[6.1.0, )",

--- a/Tests/ArchitectureTests/Todo.ArchitectureTests/packages.lock.json
+++ b/Tests/ArchitectureTests/Todo.ArchitectureTests/packages.lock.json
@@ -151,6 +151,14 @@
           "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "Lu41BWNmwhKr6LgyQvcYBOge0pPvmiaK8R5UHXX4//wBhonJyWcT2OK1mqYfEM5G7pTf31fPrpIHOT6sN7EGOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -165,6 +173,14 @@
         "contentHash": "vAuFMOvK68JIW0NlLp1mJkQxsJ2hGmLKRE2rOyIffZ/L0Xvr6hsPMF8thxPGTcgOM6eezisSTTVVHdByY6ejbQ==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "WryksPlAFFRMWIGpFwDDbrVSD/kSO7P7fRRzBHh6vEIrgflsM8tpPCcgIvKszH4fz4vcuapih9RMdiiJ2VS7aw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "3.1.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -379,23 +395,22 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "GuCTKn2pLtTzhP7GY6Y5M+DmuGQLfZL07xty8nX+/p5u0637+X2H1EJuE2p5hC18GgfMcV1y5O/haMcAN3a28Q==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.1.0",
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.2",
-          "System.Collections.Immutable": "1.4.0",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "Microsoft.Extensions.Options": "5.0.0",
+          "OpenTelemetry.Api": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "QnMZOFX9xj7aHaAK8f81wMV6yzW7Ba3DtPFcLhqrmg9g00eXRrE/RCvZp6PemZCnISKY2q5O2y/rmSKzvTMlpA==",
         "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "System.Diagnostics.DiagnosticSource": "7.0.0-rc.1.22426.10"
         }
       },
       "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": {
@@ -406,38 +421,38 @@
           "OpenTelemetry.Api": "1.0.1"
         }
       },
-      "OpenTelemetry.Contrib.Preview": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta2",
-        "contentHash": "febtaMVJAMZ2+EHntqvMXvcsMEkA5F5FXKwODz9LM0UjJ5gfNTqjY36YTddPASEZBn0a6YLRqovRW1QnMJ46NQ==",
-        "dependencies": {
-          "OpenTelemetry": "1.1.0-beta3"
-        }
-      },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "xvW5FhG9UcYdVdd6yRHpRXbg1RpS4eEGi8zQGc8PWpsbXiv4pRiiuXxpu5niLKsGU0OVkExhobQgFMKiPOwPzw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.2",
+          "OpenTelemetry": "1.4.0-beta.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
+        }
+      },
+      "OpenTelemetry.Extensions": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "XJoH2cyClDFJTCZPlNlsfq+si6f1HWdSHcVZyXQmQhw5w+DxXccKbLRRBo7Dn/l3brMIRna+1ZAXc68Y6SMCfA==",
+        "dependencies": {
+          "OpenTelemetry": "[1.4.0-beta.2]"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "AlodOzqLW+/FOB0fdlhVfk7r6/wkNFgVr/eitugdPE9IEI3WU1PT8VYDPVE2M+Xyof8+k2pjvQKn6IejrybYUQ==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "pnUHhcF86azvEQ9sjccvwP5o606TY8m0hngP11jn9Jfg6k4fPCbh5+p5Uqbv2MCgZyecWw5YIa/zoz3OA7MNbQ==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "2.1.0",
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "//6Qy9iMjpA9JiGmX9xx2GQUB/WL3Fr4Z21naWdTQuhpc+4uLOxQDWCD1rfDZHi6S8S4HluatNZISZ4Mow+YNg==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "Os0mT2ogoKBbK8z6c0lDJ/sCOq6vfR3F8pYfOFA9Hn26YMqVsfO5JO2JKzOdaOOmAFACDkv2VI4qiPVvKKqUUA==",
         "dependencies": {
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "Serilog": {
@@ -569,11 +584,6 @@
           "Serilog.Sinks.PeriodicBatching": "3.1.0"
         }
       },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "71hw5RUJRu5+q/geUY69gpXD8Upd12cH+F3MwpXV2zle7Bqqkrmc1JblOTuvUcgmdnUtQvBlV5e1d6RH+H2lvA=="
-      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
         "resolved": "4.4.0",
@@ -595,11 +605,6 @@
           "Microsoft.IdentityModel.JsonWebTokens": "6.25.1",
           "Microsoft.IdentityModel.Tokens": "6.25.1"
         }
-      },
-      "System.Reflection.Emit.Lightweight": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -678,12 +683,12 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.2, )",
+          "OpenTelemetry": "[1.4.0-beta.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
-          "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
-          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.4.0-beta.2, )",
+          "OpenTelemetry.Extensions": "[1.0.0-beta.3, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.8, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.8, )",
           "Serilog.AspNetCore": "[6.1.0, )",
           "Serilog.Enrichers.Span": "[3.0.0, )",
           "Serilog.Enrichers.Thread": "[3.1.0, )",

--- a/Tests/Infrastructure/Todo.WebApi.TestInfrastructure/packages.lock.json
+++ b/Tests/Infrastructure/Todo.WebApi.TestInfrastructure/packages.lock.json
@@ -21,9 +21,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",
@@ -470,20 +470,20 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "PWIl/juBJBFi4Adx07nltkxA2ZCwutd2A+KAvO3TOYV+xeIiN6afT5bE4W3EebqdDV0T3buq/vAlQ2ZDC9zYew==",
+        "resolved": "1.3.2",
+        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.1",
+          "OpenTelemetry.Api": "1.3.2",
           "System.Collections.Immutable": "1.4.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "p4ufCQ+afYMEYh1pF8K5huhJ4PnYVvKvje+GjhiDPRrQTmwto5nl8spjeK9N1OXg2HFmGuMXQvc8y90RoNLekg==",
+        "resolved": "1.3.2",
+        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -507,10 +507,10 @@
       },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "+JJyvuKDBn4PqY1vH8b3bneniEizakCVstddZxkiTiVMO5+vJDZg2qLCDrfZIZYpv/SKcVty/qLTR2Qhb3Opxw==",
+        "resolved": "1.3.2",
+        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.1",
+          "OpenTelemetry": "1.3.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
         }
       },
@@ -769,10 +769,10 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.1, )",
+          "OpenTelemetry": "[1.3.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
           "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
           "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
           "Serilog.AspNetCore": "[6.1.0, )",

--- a/Tests/Infrastructure/Todo.WebApi.TestInfrastructure/packages.lock.json
+++ b/Tests/Infrastructure/Todo.WebApi.TestInfrastructure/packages.lock.json
@@ -470,23 +470,22 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "GuCTKn2pLtTzhP7GY6Y5M+DmuGQLfZL07xty8nX+/p5u0637+X2H1EJuE2p5hC18GgfMcV1y5O/haMcAN3a28Q==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.1.0",
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.2",
-          "System.Collections.Immutable": "1.4.0",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "Microsoft.Extensions.Options": "5.0.0",
+          "OpenTelemetry.Api": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "QnMZOFX9xj7aHaAK8f81wMV6yzW7Ba3DtPFcLhqrmg9g00eXRrE/RCvZp6PemZCnISKY2q5O2y/rmSKzvTMlpA==",
         "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "System.Diagnostics.DiagnosticSource": "7.0.0-rc.1.22426.10"
         }
       },
       "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": {
@@ -497,38 +496,38 @@
           "OpenTelemetry.Api": "1.0.1"
         }
       },
-      "OpenTelemetry.Contrib.Preview": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta2",
-        "contentHash": "febtaMVJAMZ2+EHntqvMXvcsMEkA5F5FXKwODz9LM0UjJ5gfNTqjY36YTddPASEZBn0a6YLRqovRW1QnMJ46NQ==",
-        "dependencies": {
-          "OpenTelemetry": "1.1.0-beta3"
-        }
-      },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "xvW5FhG9UcYdVdd6yRHpRXbg1RpS4eEGi8zQGc8PWpsbXiv4pRiiuXxpu5niLKsGU0OVkExhobQgFMKiPOwPzw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.2",
+          "OpenTelemetry": "1.4.0-beta.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
+        }
+      },
+      "OpenTelemetry.Extensions": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "XJoH2cyClDFJTCZPlNlsfq+si6f1HWdSHcVZyXQmQhw5w+DxXccKbLRRBo7Dn/l3brMIRna+1ZAXc68Y6SMCfA==",
+        "dependencies": {
+          "OpenTelemetry": "[1.4.0-beta.2]"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "AlodOzqLW+/FOB0fdlhVfk7r6/wkNFgVr/eitugdPE9IEI3WU1PT8VYDPVE2M+Xyof8+k2pjvQKn6IejrybYUQ==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "pnUHhcF86azvEQ9sjccvwP5o606TY8m0hngP11jn9Jfg6k4fPCbh5+p5Uqbv2MCgZyecWw5YIa/zoz3OA7MNbQ==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "2.1.0",
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "//6Qy9iMjpA9JiGmX9xx2GQUB/WL3Fr4Z21naWdTQuhpc+4uLOxQDWCD1rfDZHi6S8S4HluatNZISZ4Mow+YNg==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "Os0mT2ogoKBbK8z6c0lDJ/sCOq6vfR3F8pYfOFA9Hn26YMqVsfO5JO2JKzOdaOOmAFACDkv2VI4qiPVvKKqUUA==",
         "dependencies": {
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "Serilog": {
@@ -660,11 +659,6 @@
           "Serilog.Sinks.PeriodicBatching": "3.1.0"
         }
       },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "71hw5RUJRu5+q/geUY69gpXD8Upd12cH+F3MwpXV2zle7Bqqkrmc1JblOTuvUcgmdnUtQvBlV5e1d6RH+H2lvA=="
-      },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -688,11 +682,6 @@
         "type": "Transitive",
         "resolved": "7.0.0",
         "contentHash": "jRn6JYnNPW6xgQazROBLSfpdoczRw694vO5kKvMcNnpXuolEixUyw6IBuBs2Y2mlSX/LdLvyyWmfXhaI3ND1Yg=="
-      },
-      "System.Reflection.Emit.Lightweight": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Runtime": {
         "type": "Transitive",
@@ -769,12 +758,12 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.2, )",
+          "OpenTelemetry": "[1.4.0-beta.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
-          "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
-          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.4.0-beta.2, )",
+          "OpenTelemetry.Extensions": "[1.0.0-beta.3, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.8, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.8, )",
           "Serilog.AspNetCore": "[6.1.0, )",
           "Serilog.Enrichers.Span": "[3.0.0, )",
           "Serilog.Enrichers.Thread": "[3.1.0, )",

--- a/Tests/IntegrationTests/Todo.ApplicationFlows.IntegrationTests/packages.lock.json
+++ b/Tests/IntegrationTests/Todo.ApplicationFlows.IntegrationTests/packages.lock.json
@@ -50,9 +50,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",
@@ -550,20 +550,20 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "PWIl/juBJBFi4Adx07nltkxA2ZCwutd2A+KAvO3TOYV+xeIiN6afT5bE4W3EebqdDV0T3buq/vAlQ2ZDC9zYew==",
+        "resolved": "1.3.2",
+        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.1",
+          "OpenTelemetry.Api": "1.3.2",
           "System.Collections.Immutable": "1.4.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "p4ufCQ+afYMEYh1pF8K5huhJ4PnYVvKvje+GjhiDPRrQTmwto5nl8spjeK9N1OXg2HFmGuMXQvc8y90RoNLekg==",
+        "resolved": "1.3.2",
+        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -587,10 +587,10 @@
       },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "+JJyvuKDBn4PqY1vH8b3bneniEizakCVstddZxkiTiVMO5+vJDZg2qLCDrfZIZYpv/SKcVty/qLTR2Qhb3Opxw==",
+        "resolved": "1.3.2",
+        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.1",
+          "OpenTelemetry": "1.3.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
         }
       },
@@ -867,10 +867,10 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.1, )",
+          "OpenTelemetry": "[1.3.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
           "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
           "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
           "Serilog.AspNetCore": "[6.1.0, )",

--- a/Tests/IntegrationTests/Todo.ApplicationFlows.IntegrationTests/packages.lock.json
+++ b/Tests/IntegrationTests/Todo.ApplicationFlows.IntegrationTests/packages.lock.json
@@ -550,23 +550,22 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "GuCTKn2pLtTzhP7GY6Y5M+DmuGQLfZL07xty8nX+/p5u0637+X2H1EJuE2p5hC18GgfMcV1y5O/haMcAN3a28Q==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.1.0",
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.2",
-          "System.Collections.Immutable": "1.4.0",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "Microsoft.Extensions.Options": "5.0.0",
+          "OpenTelemetry.Api": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "QnMZOFX9xj7aHaAK8f81wMV6yzW7Ba3DtPFcLhqrmg9g00eXRrE/RCvZp6PemZCnISKY2q5O2y/rmSKzvTMlpA==",
         "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "System.Diagnostics.DiagnosticSource": "7.0.0-rc.1.22426.10"
         }
       },
       "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": {
@@ -577,38 +576,38 @@
           "OpenTelemetry.Api": "1.0.1"
         }
       },
-      "OpenTelemetry.Contrib.Preview": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta2",
-        "contentHash": "febtaMVJAMZ2+EHntqvMXvcsMEkA5F5FXKwODz9LM0UjJ5gfNTqjY36YTddPASEZBn0a6YLRqovRW1QnMJ46NQ==",
-        "dependencies": {
-          "OpenTelemetry": "1.1.0-beta3"
-        }
-      },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "xvW5FhG9UcYdVdd6yRHpRXbg1RpS4eEGi8zQGc8PWpsbXiv4pRiiuXxpu5niLKsGU0OVkExhobQgFMKiPOwPzw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.2",
+          "OpenTelemetry": "1.4.0-beta.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
+        }
+      },
+      "OpenTelemetry.Extensions": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "XJoH2cyClDFJTCZPlNlsfq+si6f1HWdSHcVZyXQmQhw5w+DxXccKbLRRBo7Dn/l3brMIRna+1ZAXc68Y6SMCfA==",
+        "dependencies": {
+          "OpenTelemetry": "[1.4.0-beta.2]"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "AlodOzqLW+/FOB0fdlhVfk7r6/wkNFgVr/eitugdPE9IEI3WU1PT8VYDPVE2M+Xyof8+k2pjvQKn6IejrybYUQ==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "pnUHhcF86azvEQ9sjccvwP5o606TY8m0hngP11jn9Jfg6k4fPCbh5+p5Uqbv2MCgZyecWw5YIa/zoz3OA7MNbQ==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "2.1.0",
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "//6Qy9iMjpA9JiGmX9xx2GQUB/WL3Fr4Z21naWdTQuhpc+4uLOxQDWCD1rfDZHi6S8S4HluatNZISZ4Mow+YNg==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "Os0mT2ogoKBbK8z6c0lDJ/sCOq6vfR3F8pYfOFA9Hn26YMqVsfO5JO2JKzOdaOOmAFACDkv2VI4qiPVvKKqUUA==",
         "dependencies": {
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "Serilog": {
@@ -740,11 +739,6 @@
           "Serilog.Sinks.PeriodicBatching": "3.1.0"
         }
       },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "71hw5RUJRu5+q/geUY69gpXD8Upd12cH+F3MwpXV2zle7Bqqkrmc1JblOTuvUcgmdnUtQvBlV5e1d6RH+H2lvA=="
-      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
         "resolved": "4.4.0",
@@ -776,11 +770,6 @@
         "type": "Transitive",
         "resolved": "7.0.0",
         "contentHash": "jRn6JYnNPW6xgQazROBLSfpdoczRw694vO5kKvMcNnpXuolEixUyw6IBuBs2Y2mlSX/LdLvyyWmfXhaI3ND1Yg=="
-      },
-      "System.Reflection.Emit.Lightweight": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -867,12 +856,12 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.2, )",
+          "OpenTelemetry": "[1.4.0-beta.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
-          "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
-          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.4.0-beta.2, )",
+          "OpenTelemetry.Extensions": "[1.0.0-beta.3, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.8, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.8, )",
           "Serilog.AspNetCore": "[6.1.0, )",
           "Serilog.Enrichers.Span": "[3.0.0, )",
           "Serilog.Enrichers.Thread": "[3.1.0, )",

--- a/Tests/IntegrationTests/Todo.Persistence.IntegrationTests/packages.lock.json
+++ b/Tests/IntegrationTests/Todo.Persistence.IntegrationTests/packages.lock.json
@@ -50,9 +50,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",
@@ -371,20 +371,20 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "PWIl/juBJBFi4Adx07nltkxA2ZCwutd2A+KAvO3TOYV+xeIiN6afT5bE4W3EebqdDV0T3buq/vAlQ2ZDC9zYew==",
+        "resolved": "1.3.2",
+        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.1",
+          "OpenTelemetry.Api": "1.3.2",
           "System.Collections.Immutable": "1.4.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "p4ufCQ+afYMEYh1pF8K5huhJ4PnYVvKvje+GjhiDPRrQTmwto5nl8spjeK9N1OXg2HFmGuMXQvc8y90RoNLekg==",
+        "resolved": "1.3.2",
+        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -408,10 +408,10 @@
       },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "+JJyvuKDBn4PqY1vH8b3bneniEizakCVstddZxkiTiVMO5+vJDZg2qLCDrfZIZYpv/SKcVty/qLTR2Qhb3Opxw==",
+        "resolved": "1.3.2",
+        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.1",
+          "OpenTelemetry": "1.3.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
         }
       },
@@ -670,10 +670,10 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.1, )",
+          "OpenTelemetry": "[1.3.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
           "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
           "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
           "Serilog.AspNetCore": "[6.1.0, )",

--- a/Tests/IntegrationTests/Todo.Persistence.IntegrationTests/packages.lock.json
+++ b/Tests/IntegrationTests/Todo.Persistence.IntegrationTests/packages.lock.json
@@ -148,6 +148,14 @@
           "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "Lu41BWNmwhKr6LgyQvcYBOge0pPvmiaK8R5UHXX4//wBhonJyWcT2OK1mqYfEM5G7pTf31fPrpIHOT6sN7EGOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -162,6 +170,14 @@
         "contentHash": "vAuFMOvK68JIW0NlLp1mJkQxsJ2hGmLKRE2rOyIffZ/L0Xvr6hsPMF8thxPGTcgOM6eezisSTTVVHdByY6ejbQ==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "WryksPlAFFRMWIGpFwDDbrVSD/kSO7P7fRRzBHh6vEIrgflsM8tpPCcgIvKszH4fz4vcuapih9RMdiiJ2VS7aw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "3.1.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -371,23 +387,22 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "GuCTKn2pLtTzhP7GY6Y5M+DmuGQLfZL07xty8nX+/p5u0637+X2H1EJuE2p5hC18GgfMcV1y5O/haMcAN3a28Q==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.1.0",
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.2",
-          "System.Collections.Immutable": "1.4.0",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "Microsoft.Extensions.Options": "5.0.0",
+          "OpenTelemetry.Api": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "QnMZOFX9xj7aHaAK8f81wMV6yzW7Ba3DtPFcLhqrmg9g00eXRrE/RCvZp6PemZCnISKY2q5O2y/rmSKzvTMlpA==",
         "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "System.Diagnostics.DiagnosticSource": "7.0.0-rc.1.22426.10"
         }
       },
       "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": {
@@ -398,38 +413,38 @@
           "OpenTelemetry.Api": "1.0.1"
         }
       },
-      "OpenTelemetry.Contrib.Preview": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta2",
-        "contentHash": "febtaMVJAMZ2+EHntqvMXvcsMEkA5F5FXKwODz9LM0UjJ5gfNTqjY36YTddPASEZBn0a6YLRqovRW1QnMJ46NQ==",
-        "dependencies": {
-          "OpenTelemetry": "1.1.0-beta3"
-        }
-      },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "xvW5FhG9UcYdVdd6yRHpRXbg1RpS4eEGi8zQGc8PWpsbXiv4pRiiuXxpu5niLKsGU0OVkExhobQgFMKiPOwPzw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.2",
+          "OpenTelemetry": "1.4.0-beta.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
+        }
+      },
+      "OpenTelemetry.Extensions": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "XJoH2cyClDFJTCZPlNlsfq+si6f1HWdSHcVZyXQmQhw5w+DxXccKbLRRBo7Dn/l3brMIRna+1ZAXc68Y6SMCfA==",
+        "dependencies": {
+          "OpenTelemetry": "[1.4.0-beta.2]"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "AlodOzqLW+/FOB0fdlhVfk7r6/wkNFgVr/eitugdPE9IEI3WU1PT8VYDPVE2M+Xyof8+k2pjvQKn6IejrybYUQ==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "pnUHhcF86azvEQ9sjccvwP5o606TY8m0hngP11jn9Jfg6k4fPCbh5+p5Uqbv2MCgZyecWw5YIa/zoz3OA7MNbQ==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "2.1.0",
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "//6Qy9iMjpA9JiGmX9xx2GQUB/WL3Fr4Z21naWdTQuhpc+4uLOxQDWCD1rfDZHi6S8S4HluatNZISZ4Mow+YNg==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "Os0mT2ogoKBbK8z6c0lDJ/sCOq6vfR3F8pYfOFA9Hn26YMqVsfO5JO2JKzOdaOOmAFACDkv2VI4qiPVvKKqUUA==",
         "dependencies": {
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "Serilog": {
@@ -561,11 +576,6 @@
           "Serilog.Sinks.PeriodicBatching": "3.1.0"
         }
       },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "71hw5RUJRu5+q/geUY69gpXD8Upd12cH+F3MwpXV2zle7Bqqkrmc1JblOTuvUcgmdnUtQvBlV5e1d6RH+H2lvA=="
-      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
         "resolved": "4.4.0",
@@ -587,11 +597,6 @@
           "Microsoft.IdentityModel.JsonWebTokens": "6.25.1",
           "Microsoft.IdentityModel.Tokens": "6.25.1"
         }
-      },
-      "System.Reflection.Emit.Lightweight": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -670,12 +675,12 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.2, )",
+          "OpenTelemetry": "[1.4.0-beta.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
-          "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
-          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.4.0-beta.2, )",
+          "OpenTelemetry.Extensions": "[1.0.0-beta.3, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.8, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.8, )",
           "Serilog.AspNetCore": "[6.1.0, )",
           "Serilog.Enrichers.Span": "[3.0.0, )",
           "Serilog.Enrichers.Thread": "[3.1.0, )",

--- a/Tests/IntegrationTests/Todo.WebApi.IntegrationTests/packages.lock.json
+++ b/Tests/IntegrationTests/Todo.WebApi.IntegrationTests/packages.lock.json
@@ -569,23 +569,22 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "GuCTKn2pLtTzhP7GY6Y5M+DmuGQLfZL07xty8nX+/p5u0637+X2H1EJuE2p5hC18GgfMcV1y5O/haMcAN3a28Q==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.1.0",
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.2",
-          "System.Collections.Immutable": "1.4.0",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "Microsoft.Extensions.Options": "5.0.0",
+          "OpenTelemetry.Api": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "QnMZOFX9xj7aHaAK8f81wMV6yzW7Ba3DtPFcLhqrmg9g00eXRrE/RCvZp6PemZCnISKY2q5O2y/rmSKzvTMlpA==",
         "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "System.Diagnostics.DiagnosticSource": "7.0.0-rc.1.22426.10"
         }
       },
       "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": {
@@ -596,38 +595,38 @@
           "OpenTelemetry.Api": "1.0.1"
         }
       },
-      "OpenTelemetry.Contrib.Preview": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta2",
-        "contentHash": "febtaMVJAMZ2+EHntqvMXvcsMEkA5F5FXKwODz9LM0UjJ5gfNTqjY36YTddPASEZBn0a6YLRqovRW1QnMJ46NQ==",
-        "dependencies": {
-          "OpenTelemetry": "1.1.0-beta3"
-        }
-      },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "xvW5FhG9UcYdVdd6yRHpRXbg1RpS4eEGi8zQGc8PWpsbXiv4pRiiuXxpu5niLKsGU0OVkExhobQgFMKiPOwPzw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.2",
+          "OpenTelemetry": "1.4.0-beta.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
+        }
+      },
+      "OpenTelemetry.Extensions": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "XJoH2cyClDFJTCZPlNlsfq+si6f1HWdSHcVZyXQmQhw5w+DxXccKbLRRBo7Dn/l3brMIRna+1ZAXc68Y6SMCfA==",
+        "dependencies": {
+          "OpenTelemetry": "[1.4.0-beta.2]"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "AlodOzqLW+/FOB0fdlhVfk7r6/wkNFgVr/eitugdPE9IEI3WU1PT8VYDPVE2M+Xyof8+k2pjvQKn6IejrybYUQ==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "pnUHhcF86azvEQ9sjccvwP5o606TY8m0hngP11jn9Jfg6k4fPCbh5+p5Uqbv2MCgZyecWw5YIa/zoz3OA7MNbQ==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "2.1.0",
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "//6Qy9iMjpA9JiGmX9xx2GQUB/WL3Fr4Z21naWdTQuhpc+4uLOxQDWCD1rfDZHi6S8S4HluatNZISZ4Mow+YNg==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "Os0mT2ogoKBbK8z6c0lDJ/sCOq6vfR3F8pYfOFA9Hn26YMqVsfO5JO2JKzOdaOOmAFACDkv2VI4qiPVvKKqUUA==",
         "dependencies": {
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "Serilog": {
@@ -759,11 +758,6 @@
           "Serilog.Sinks.PeriodicBatching": "3.1.0"
         }
       },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "71hw5RUJRu5+q/geUY69gpXD8Upd12cH+F3MwpXV2zle7Bqqkrmc1JblOTuvUcgmdnUtQvBlV5e1d6RH+H2lvA=="
-      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
         "resolved": "4.4.0",
@@ -795,11 +789,6 @@
         "type": "Transitive",
         "resolved": "7.0.0",
         "contentHash": "jRn6JYnNPW6xgQazROBLSfpdoczRw694vO5kKvMcNnpXuolEixUyw6IBuBs2Y2mlSX/LdLvyyWmfXhaI3ND1Yg=="
-      },
-      "System.Reflection.Emit.Lightweight": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -886,12 +875,12 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.2, )",
+          "OpenTelemetry": "[1.4.0-beta.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
-          "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
-          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.4.0-beta.2, )",
+          "OpenTelemetry.Extensions": "[1.0.0-beta.3, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.8, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.8, )",
           "Serilog.AspNetCore": "[6.1.0, )",
           "Serilog.Enrichers.Span": "[3.0.0, )",
           "Serilog.Enrichers.Thread": "[3.1.0, )",

--- a/Tests/IntegrationTests/Todo.WebApi.IntegrationTests/packages.lock.json
+++ b/Tests/IntegrationTests/Todo.WebApi.IntegrationTests/packages.lock.json
@@ -60,9 +60,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",
@@ -569,20 +569,20 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "PWIl/juBJBFi4Adx07nltkxA2ZCwutd2A+KAvO3TOYV+xeIiN6afT5bE4W3EebqdDV0T3buq/vAlQ2ZDC9zYew==",
+        "resolved": "1.3.2",
+        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.1",
+          "OpenTelemetry.Api": "1.3.2",
           "System.Collections.Immutable": "1.4.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "p4ufCQ+afYMEYh1pF8K5huhJ4PnYVvKvje+GjhiDPRrQTmwto5nl8spjeK9N1OXg2HFmGuMXQvc8y90RoNLekg==",
+        "resolved": "1.3.2",
+        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -606,10 +606,10 @@
       },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "+JJyvuKDBn4PqY1vH8b3bneniEizakCVstddZxkiTiVMO5+vJDZg2qLCDrfZIZYpv/SKcVty/qLTR2Qhb3Opxw==",
+        "resolved": "1.3.2",
+        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.1",
+          "OpenTelemetry": "1.3.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
         }
       },
@@ -886,10 +886,10 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.1, )",
+          "OpenTelemetry": "[1.3.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
           "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
           "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
           "Serilog.AspNetCore": "[6.1.0, )",

--- a/Tests/UnitTests/Todo.ApplicationFlows.UnitTests/packages.lock.json
+++ b/Tests/UnitTests/Todo.ApplicationFlows.UnitTests/packages.lock.json
@@ -59,9 +59,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",

--- a/Tests/UnitTests/Todo.Services.UnitTests/packages.lock.json
+++ b/Tests/UnitTests/Todo.Services.UnitTests/packages.lock.json
@@ -80,9 +80,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",

--- a/Tests/UnitTests/Todo.Telemetry.UnitTests/packages.lock.json
+++ b/Tests/UnitTests/Todo.Telemetry.UnitTests/packages.lock.json
@@ -148,6 +148,14 @@
           "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "Lu41BWNmwhKr6LgyQvcYBOge0pPvmiaK8R5UHXX4//wBhonJyWcT2OK1mqYfEM5G7pTf31fPrpIHOT6sN7EGOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -162,6 +170,14 @@
         "contentHash": "vAuFMOvK68JIW0NlLp1mJkQxsJ2hGmLKRE2rOyIffZ/L0Xvr6hsPMF8thxPGTcgOM6eezisSTTVVHdByY6ejbQ==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "WryksPlAFFRMWIGpFwDDbrVSD/kSO7P7fRRzBHh6vEIrgflsM8tpPCcgIvKszH4fz4vcuapih9RMdiiJ2VS7aw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "3.1.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -353,23 +369,22 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "GuCTKn2pLtTzhP7GY6Y5M+DmuGQLfZL07xty8nX+/p5u0637+X2H1EJuE2p5hC18GgfMcV1y5O/haMcAN3a28Q==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.1.0",
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.2",
-          "System.Collections.Immutable": "1.4.0",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "Microsoft.Extensions.Options": "5.0.0",
+          "OpenTelemetry.Api": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "QnMZOFX9xj7aHaAK8f81wMV6yzW7Ba3DtPFcLhqrmg9g00eXRrE/RCvZp6PemZCnISKY2q5O2y/rmSKzvTMlpA==",
         "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "System.Diagnostics.DiagnosticSource": "7.0.0-rc.1.22426.10"
         }
       },
       "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": {
@@ -380,38 +395,38 @@
           "OpenTelemetry.Api": "1.0.1"
         }
       },
-      "OpenTelemetry.Contrib.Preview": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta2",
-        "contentHash": "febtaMVJAMZ2+EHntqvMXvcsMEkA5F5FXKwODz9LM0UjJ5gfNTqjY36YTddPASEZBn0a6YLRqovRW1QnMJ46NQ==",
-        "dependencies": {
-          "OpenTelemetry": "1.1.0-beta3"
-        }
-      },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "xvW5FhG9UcYdVdd6yRHpRXbg1RpS4eEGi8zQGc8PWpsbXiv4pRiiuXxpu5niLKsGU0OVkExhobQgFMKiPOwPzw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.2",
+          "OpenTelemetry": "1.4.0-beta.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
+        }
+      },
+      "OpenTelemetry.Extensions": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "XJoH2cyClDFJTCZPlNlsfq+si6f1HWdSHcVZyXQmQhw5w+DxXccKbLRRBo7Dn/l3brMIRna+1ZAXc68Y6SMCfA==",
+        "dependencies": {
+          "OpenTelemetry": "[1.4.0-beta.2]"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "AlodOzqLW+/FOB0fdlhVfk7r6/wkNFgVr/eitugdPE9IEI3WU1PT8VYDPVE2M+Xyof8+k2pjvQKn6IejrybYUQ==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "pnUHhcF86azvEQ9sjccvwP5o606TY8m0hngP11jn9Jfg6k4fPCbh5+p5Uqbv2MCgZyecWw5YIa/zoz3OA7MNbQ==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "2.1.0",
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "//6Qy9iMjpA9JiGmX9xx2GQUB/WL3Fr4Z21naWdTQuhpc+4uLOxQDWCD1rfDZHi6S8S4HluatNZISZ4Mow+YNg==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "Os0mT2ogoKBbK8z6c0lDJ/sCOq6vfR3F8pYfOFA9Hn26YMqVsfO5JO2JKzOdaOOmAFACDkv2VI4qiPVvKKqUUA==",
         "dependencies": {
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "Serilog": {
@@ -543,11 +558,6 @@
           "Serilog.Sinks.PeriodicBatching": "3.1.0"
         }
       },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "71hw5RUJRu5+q/geUY69gpXD8Upd12cH+F3MwpXV2zle7Bqqkrmc1JblOTuvUcgmdnUtQvBlV5e1d6RH+H2lvA=="
-      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
         "resolved": "4.4.0",
@@ -574,11 +584,6 @@
           "Microsoft.IdentityModel.JsonWebTokens": "6.25.1",
           "Microsoft.IdentityModel.Tokens": "6.25.1"
         }
-      },
-      "System.Reflection.Emit.Lightweight": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -650,12 +655,12 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.2, )",
+          "OpenTelemetry": "[1.4.0-beta.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
-          "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
-          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.4.0-beta.2, )",
+          "OpenTelemetry.Extensions": "[1.0.0-beta.3, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.8, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.8, )",
           "Serilog.AspNetCore": "[6.1.0, )",
           "Serilog.Enrichers.Span": "[3.0.0, )",
           "Serilog.Enrichers.Thread": "[3.1.0, )",

--- a/Tests/UnitTests/Todo.Telemetry.UnitTests/packages.lock.json
+++ b/Tests/UnitTests/Todo.Telemetry.UnitTests/packages.lock.json
@@ -59,9 +59,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",
@@ -353,20 +353,20 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "PWIl/juBJBFi4Adx07nltkxA2ZCwutd2A+KAvO3TOYV+xeIiN6afT5bE4W3EebqdDV0T3buq/vAlQ2ZDC9zYew==",
+        "resolved": "1.3.2",
+        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.1",
+          "OpenTelemetry.Api": "1.3.2",
           "System.Collections.Immutable": "1.4.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "p4ufCQ+afYMEYh1pF8K5huhJ4PnYVvKvje+GjhiDPRrQTmwto5nl8spjeK9N1OXg2HFmGuMXQvc8y90RoNLekg==",
+        "resolved": "1.3.2",
+        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -390,10 +390,10 @@
       },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "+JJyvuKDBn4PqY1vH8b3bneniEizakCVstddZxkiTiVMO5+vJDZg2qLCDrfZIZYpv/SKcVty/qLTR2Qhb3Opxw==",
+        "resolved": "1.3.2",
+        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.1",
+          "OpenTelemetry": "1.3.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
         }
       },
@@ -650,10 +650,10 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.1, )",
+          "OpenTelemetry": "[1.3.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
           "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
           "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
           "Serilog.AspNetCore": "[6.1.0, )",

--- a/Tests/UnitTests/Todo.WebApi.UnitTests/packages.lock.json
+++ b/Tests/UnitTests/Todo.WebApi.UnitTests/packages.lock.json
@@ -59,9 +59,9 @@
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
-        "requested": "[8.50.0.58025, )",
-        "resolved": "8.50.0.58025",
-        "contentHash": "mL8bFUXsCeMYKmG9dT8VKLEEZccvscL9XQcvlzUCP+aBn+PHRskoWGjjC1BevquCYB++OM7mHwLAaQFOuuOPIw=="
+        "requested": "[8.51.0.59060, )",
+        "resolved": "8.51.0.59060",
+        "contentHash": "Wh4sFITqQhNKiRad5poG5oe+PvnQ5HqnZ9ddJ57HrNOaw9LtRPejEo7EEGXMSRAHFd6WXhF/ubIcBDoG5gLaAA=="
       },
       "Autofac": {
         "type": "Transitive",
@@ -388,20 +388,20 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "PWIl/juBJBFi4Adx07nltkxA2ZCwutd2A+KAvO3TOYV+xeIiN6afT5bE4W3EebqdDV0T3buq/vAlQ2ZDC9zYew==",
+        "resolved": "1.3.2",
+        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.1",
+          "OpenTelemetry.Api": "1.3.2",
           "System.Collections.Immutable": "1.4.0",
           "System.Reflection.Emit.Lightweight": "4.7.0"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "p4ufCQ+afYMEYh1pF8K5huhJ4PnYVvKvje+GjhiDPRrQTmwto5nl8spjeK9N1OXg2HFmGuMXQvc8y90RoNLekg==",
+        "resolved": "1.3.2",
+        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
         "dependencies": {
           "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
           "System.Reflection.Emit.Lightweight": "4.7.0"
@@ -425,10 +425,10 @@
       },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.1",
-        "contentHash": "+JJyvuKDBn4PqY1vH8b3bneniEizakCVstddZxkiTiVMO5+vJDZg2qLCDrfZIZYpv/SKcVty/qLTR2Qhb3Opxw==",
+        "resolved": "1.3.2",
+        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.1",
+          "OpenTelemetry": "1.3.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
         }
       },
@@ -692,10 +692,10 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.1, )",
+          "OpenTelemetry": "[1.3.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
           "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
           "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
           "Serilog.AspNetCore": "[6.1.0, )",

--- a/Tests/UnitTests/Todo.WebApi.UnitTests/packages.lock.json
+++ b/Tests/UnitTests/Todo.WebApi.UnitTests/packages.lock.json
@@ -165,6 +165,14 @@
           "Microsoft.Extensions.Primitives": "7.0.0"
         }
       },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "Lu41BWNmwhKr6LgyQvcYBOge0pPvmiaK8R5UHXX4//wBhonJyWcT2OK1mqYfEM5G7pTf31fPrpIHOT6sN7EGOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "3.1.0"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Transitive",
         "resolved": "7.0.0",
@@ -179,6 +187,14 @@
         "contentHash": "vAuFMOvK68JIW0NlLp1mJkQxsJ2hGmLKRE2rOyIffZ/L0Xvr6hsPMF8thxPGTcgOM6eezisSTTVVHdByY6ejbQ==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "7.0.0"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "WryksPlAFFRMWIGpFwDDbrVSD/kSO7P7fRRzBHh6vEIrgflsM8tpPCcgIvKszH4fz4vcuapih9RMdiiJ2VS7aw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "3.1.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -388,23 +404,22 @@
       },
       "OpenTelemetry": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "j6m197nGyxEsjH+QRPmCqq6mmoxS+bEY6zNRf6YdcYcU/vdbXKfol/QrGFLeSO0BWH+KgkA3G1AQegxN796pwg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "GuCTKn2pLtTzhP7GY6Y5M+DmuGQLfZL07xty8nX+/p5u0637+X2H1EJuE2p5hC18GgfMcV1y5O/haMcAN3a28Q==",
         "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "3.1.0",
           "Microsoft.Extensions.Logging": "3.1.0",
           "Microsoft.Extensions.Logging.Configuration": "3.1.0",
-          "OpenTelemetry.Api": "1.3.2",
-          "System.Collections.Immutable": "1.4.0",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "Microsoft.Extensions.Options": "5.0.0",
+          "OpenTelemetry.Api": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Api": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "bIGrRKolc1QxtWv1Ed/o5MWd3qB7IhfVB1bu7opKutDzS82J9bgwr3LXqnPw9xiwYuRasoo0qO2rxaCaZFqmkg==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "QnMZOFX9xj7aHaAK8f81wMV6yzW7Ba3DtPFcLhqrmg9g00eXRrE/RCvZp6PemZCnISKY2q5O2y/rmSKzvTMlpA==",
         "dependencies": {
-          "System.Diagnostics.DiagnosticSource": "[6.0.0, 8.0.0)",
-          "System.Reflection.Emit.Lightweight": "4.7.0"
+          "System.Diagnostics.DiagnosticSource": "7.0.0-rc.1.22426.10"
         }
       },
       "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": {
@@ -415,38 +430,38 @@
           "OpenTelemetry.Api": "1.0.1"
         }
       },
-      "OpenTelemetry.Contrib.Preview": {
-        "type": "Transitive",
-        "resolved": "1.0.0-beta2",
-        "contentHash": "febtaMVJAMZ2+EHntqvMXvcsMEkA5F5FXKwODz9LM0UjJ5gfNTqjY36YTddPASEZBn0a6YLRqovRW1QnMJ46NQ==",
-        "dependencies": {
-          "OpenTelemetry": "1.1.0-beta3"
-        }
-      },
       "OpenTelemetry.Exporter.Jaeger": {
         "type": "Transitive",
-        "resolved": "1.3.2",
-        "contentHash": "Dt8vZzIY264suxo+rRBTv9hVD4WIC8rQYVd88SfcA4jlqgBPTN2T+LzUczVwdanW3EcbxqAPYogGAxy0dArAZw==",
+        "resolved": "1.4.0-beta.2",
+        "contentHash": "xvW5FhG9UcYdVdd6yRHpRXbg1RpS4eEGi8zQGc8PWpsbXiv4pRiiuXxpu5niLKsGU0OVkExhobQgFMKiPOwPzw==",
         "dependencies": {
-          "OpenTelemetry": "1.3.2",
+          "OpenTelemetry": "1.4.0-beta.2",
           "System.Threading.Tasks.Extensions": "4.5.3"
+        }
+      },
+      "OpenTelemetry.Extensions": {
+        "type": "Transitive",
+        "resolved": "1.0.0-beta.3",
+        "contentHash": "XJoH2cyClDFJTCZPlNlsfq+si6f1HWdSHcVZyXQmQhw5w+DxXccKbLRRBo7Dn/l3brMIRna+1ZAXc68Y6SMCfA==",
+        "dependencies": {
+          "OpenTelemetry": "[1.4.0-beta.2]"
         }
       },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "AlodOzqLW+/FOB0fdlhVfk7r6/wkNFgVr/eitugdPE9IEI3WU1PT8VYDPVE2M+Xyof8+k2pjvQKn6IejrybYUQ==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "pnUHhcF86azvEQ9sjccvwP5o606TY8m0hngP11jn9Jfg6k4fPCbh5+p5Uqbv2MCgZyecWw5YIa/zoz3OA7MNbQ==",
         "dependencies": {
           "Microsoft.Extensions.Hosting.Abstractions": "2.1.0",
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "OpenTelemetry.Instrumentation.AspNetCore": {
         "type": "Transitive",
-        "resolved": "1.0.0-rc9.1",
-        "contentHash": "//6Qy9iMjpA9JiGmX9xx2GQUB/WL3Fr4Z21naWdTQuhpc+4uLOxQDWCD1rfDZHi6S8S4HluatNZISZ4Mow+YNg==",
+        "resolved": "1.0.0-rc9.8",
+        "contentHash": "Os0mT2ogoKBbK8z6c0lDJ/sCOq6vfR3F8pYfOFA9Hn26YMqVsfO5JO2JKzOdaOOmAFACDkv2VI4qiPVvKKqUUA==",
         "dependencies": {
-          "OpenTelemetry": "1.2.0-rc4"
+          "OpenTelemetry": "1.4.0-beta.2"
         }
       },
       "Serilog": {
@@ -578,11 +593,6 @@
           "Serilog.Sinks.PeriodicBatching": "3.1.0"
         }
       },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "1.4.0",
-        "contentHash": "71hw5RUJRu5+q/geUY69gpXD8Upd12cH+F3MwpXV2zle7Bqqkrmc1JblOTuvUcgmdnUtQvBlV5e1d6RH+H2lvA=="
-      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
         "resolved": "4.4.0",
@@ -609,11 +619,6 @@
           "Microsoft.IdentityModel.JsonWebTokens": "6.25.1",
           "Microsoft.IdentityModel.Tokens": "6.25.1"
         }
-      },
-      "System.Reflection.Emit.Lightweight": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "a4OLB4IITxAXJeV74MDx49Oq2+PsF6Sml54XAFv+2RyWwtDBcabzoxiiJRhdhx+gaohLh4hEGCLQyBozXoQPqA=="
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
@@ -692,12 +697,12 @@
       "todo.telemetry": {
         "type": "Project",
         "dependencies": {
-          "OpenTelemetry": "[1.3.2, )",
+          "OpenTelemetry": "[1.4.0-beta.2, )",
           "OpenTelemetry.Contrib.Instrumentation.EntityFrameworkCore": "[1.0.0-beta2, )",
-          "OpenTelemetry.Contrib.Preview": "[1.0.0-beta2, )",
-          "OpenTelemetry.Exporter.Jaeger": "[1.3.2, )",
-          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.1, )",
-          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.1, )",
+          "OpenTelemetry.Exporter.Jaeger": "[1.4.0-beta.2, )",
+          "OpenTelemetry.Extensions": "[1.0.0-beta.3, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.0.0-rc9.8, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.0.0-rc9.8, )",
           "Serilog.AspNetCore": "[6.1.0, )",
           "Serilog.Enrichers.Span": "[3.0.0, )",
           "Serilog.Enrichers.Thread": "[3.1.0, )",


### PR DESCRIPTION
- Replaced OpenTelemetry.Contrib.Preview NuGet package with OpenTelemetry.Extensions to use the newer approach of exporting log events produced by an ILogger instance to the active Activity instance to see them via Jaeger
- Updated the rest of OpenTelemetry related NuGet packages to their last versions compatible with OpenTelemetry v1.4.0-beta.2 since this one is needed by OpenTelemetry.Extensions NuGet package