### PR TITLE
Update code coverage settings

### DIFF
--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -604,15 +604,6 @@ jobs:
         --output $(Build.SourcesDirectory)/Tests/AcceptanceTests
         --output-type HTML
 
-  # Publish the HTML document storing living doc.
-  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=blakyaks.azure-pipelines-html-reports.
-  - task: PublishHtmlReport@1
-    displayName: 'Publish living doc'
-    inputs:
-        reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
-        useFilenameTabs: True
-        tabName: 'Living Doc ($(Agent.OS)-$(Agent.OSArchitecture))'
-
   # Publish test related artifacts.
   # See more here: https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-a-pipeline-artifact.
   #

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -248,7 +248,7 @@ jobs:
       --logger "nunit"
       --filter "TestCategory=UnitTests"
       /p:CollectCoverage=true
-      /p:CoverletOutputFormat=\"json,cobertura,opencover\"
+      /p:CoverletOutputFormat=\"opencover\"
       /p:Exclude=\"[Todo.*Tests]*,[Todo.*.TestInfrastructure]*\"
       /p:Include=\"[Todo.*]*\"
     name: 'run_unit_tests'
@@ -352,7 +352,7 @@ jobs:
       --logger "nunit"
       --filter "TestCategory=IntegrationTests"
       /p:CollectCoverage=true
-      /p:CoverletOutputFormat=\"json,cobertura,opencover\"
+      /p:CoverletOutputFormat=\"opencover\"
       /p:Exclude=\"[Todo.*Tests]*,[Todo.*.TestInfrastructure]*\"
       /p:Include=\"[Todo.*]*\"
     name: 'run_integration_tests'
@@ -471,7 +471,7 @@ jobs:
   # enable Azure Boards for your project, as documented here: https://developercommunity.visualstudio.com/solutions/403137/view.html.
   - script: >-
       $(Build.SourcesDirectory)/Tests/.ReportGenerator/reportgenerator
-      "-reports:$(Build.SourcesDirectory)/Tests/**/coverage.cobertura.xml"
+      "-reports:$(Build.SourcesDirectory)/Tests/**/coverage.opencover.xml"
       "-targetdir:$(Build.SourcesDirectory)/Tests/.CodeCoverageReport"
       "-reporttypes:Cobertura"
       "-assemblyfilters:+Todo.*;-Todo.*Tests;-Todo.*.TestInfrastructure"

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -623,11 +623,13 @@ jobs:
       path: '$(Build.SourcesDirectory)/Tests'
 
   # Publish the HTML document storing living doc.
-  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=LakshayKaushik.PublishHTMLReports.
-  - task: publishhtmlreport@1
+  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=blakyaks.azure-pipelines-html-reports.
+  - task: PublishHtmlReport@1
+    displayName: 'Publish HTML Report'
     inputs:
-      htmlType: 'genericHTML'
-      htmlPath: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
+      reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
+      useFilenameTabs: True
+      tabName: 'Living Doc'
 
   # Run Sonar analysis.
   - task: SonarCloudAnalyze@3

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -604,6 +604,15 @@ jobs:
         --output $(Build.SourcesDirectory)/Tests/AcceptanceTests
         --output-type HTML
 
+  # Publish the HTML document storing living doc.
+  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=blakyaks.azure-pipelines-html-reports.
+  - task: PublishHtmlReport@1
+    displayName: 'Publish living doc'
+    inputs:
+        reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
+        useFilenameTabs: True
+        tabName: 'Living Doc ($(Agent.OS)-$(Agent.OSArchitecture))'
+
   # Publish test related artifacts.
   # See more here: https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-a-pipeline-artifact.
   #
@@ -621,15 +630,6 @@ jobs:
     inputs:
       artifact: 'test-artifacts-$(Agent.OS)-$(Agent.OSArchitecture)-$(Build.BuildNumber)-$(Build.BuildID)'
       path: '$(Build.SourcesDirectory)/Tests'
-
-  # Publish the HTML document storing living doc.
-  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=blakyaks.azure-pipelines-html-reports.
-  - task: PublishHtmlReport@1
-    displayName: 'Publish HTML Report'
-    inputs:
-      reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
-      useFilenameTabs: True
-      tabName: 'Living Doc ($(Agent.OS)-$(Agent.OSArchitecture))'
 
   # Run Sonar analysis.
   - task: SonarCloudAnalyze@3

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -127,7 +127,6 @@ jobs:
         sonar.sourceEncoding=${{ parameters.sonar.sourceEncoding }}
         sonar.cs.nunit.reportsPaths=$(Build.SourcesDirectory)/Tests/**/TestResults/TestResults.xml
         sonar.cs.opencover.reportsPaths=$(Build.SourcesDirectory)/Tests/**/coverage.opencover.xml
-        sonar.coverage.exclusions=$(Build.SourcesDirectory)/Tests/**
         sonar.analysis.buildNumber=$(Build.BuildId)
         sonar.analysis.pipeline=$(Build.BuildId)
 
@@ -240,8 +239,6 @@ jobs:
   # See more about running selective tests here: https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests#nunit.
   # Decorate the AssemblyInfo.cs found inside each unit test related project with:
   #     [assembly: NUnit.Framework.Category("UnitTests")]
-  # The magic "--%" fragment is needed to avoid an MSBuild error: "MSBUILD : error MSB1006: Property is not valid."; read more about it
-  # here: https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/MSBuildIntegration.md#coverlet-integration-with-msbuild.
   - script: >-
       dotnet test $(Build.SourcesDirectory)/$(SolutionFileName)
       --no-build
@@ -252,6 +249,8 @@ jobs:
       --filter "TestCategory=UnitTests"
       /p:CollectCoverage=true
       /p:CoverletOutputFormat=\"json,cobertura,opencover\"
+      /p:Exclude=\"[Todo.*Tests]*;[Todo.*.TestInfrastructure]*\"
+      /p:Include=\"[Todo.*]*\"
     name: 'run_unit_tests'
     displayName: 'Run unit tests'
     condition: |
@@ -354,6 +353,8 @@ jobs:
       --filter "TestCategory=IntegrationTests"
       /p:CollectCoverage=true
       /p:CoverletOutputFormat=\"json,cobertura,opencover\"
+      /p:Exclude=\"[Todo.*Tests]*;[Todo.*.TestInfrastructure]*\"
+      /p:Include=\"[Todo.*]*\"
     name: 'run_integration_tests'
     displayName: 'Run integration tests'
     condition: |

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -622,6 +622,13 @@ jobs:
       artifact: 'test-artifacts-$(Agent.OS)-$(Agent.OSArchitecture)-$(Build.BuildNumber)-$(Build.BuildID)'
       path: '$(Build.SourcesDirectory)/Tests'
 
+  # Publish the HTML document storing living doc.
+  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=LakshayKaushik.PublishHTMLReports.
+  - task: publishhtmlreport@1
+    inputs:
+      htmlType: 'genericHTML'
+      htmlPath: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
+
   # Run Sonar analysis.
   - task: SonarCloudAnalyze@3
     name: 'run_sonar_analysis'

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -227,7 +227,7 @@ jobs:
         , eq(${{ parameters.tests.runTests }}, True)
       )
     inputs:
-      testRunTitle: 'Todo Web API - Architecture Tests ($(Agent.OS) $(Agent.OSArchitecture))'
+      testRunTitle: 'Todo Web API - Architecture Tests ($(Agent.OS)-$(Agent.OSArchitecture))'
       testResultsFormat: 'NUnit'
       testResultsFiles: '$(Build.SourcesDirectory)/Tests/ArchitectureTests/**/TestResults/TestResults.xml'
       mergeTestResults: True
@@ -283,7 +283,7 @@ jobs:
         , eq(variables['ArchitectureTestsOutcome'], 'success')
       )
     inputs:
-      testRunTitle: 'Todo Web API - Unit Tests ($(Agent.OS) $(Agent.OSArchitecture))'
+      testRunTitle: 'Todo Web API - Unit Tests ($(Agent.OS)-$(Agent.OSArchitecture))'
       testResultsFormat: 'NUnit'
       testResultsFiles: '$(Build.SourcesDirectory)/Tests/UnitTests/**/TestResults/TestResults.xml'
       mergeTestResults: True
@@ -440,7 +440,7 @@ jobs:
         , eq(variables['UnitTestsOutcome'], 'success')
       )
     inputs:
-      testRunTitle: 'Todo Web API - Integration Tests ($(Agent.OS) $(Agent.OSArchitecture))'
+      testRunTitle: 'Todo Web API - Integration Tests ($(Agent.OS)-$(Agent.OSArchitecture))'
       testResultsFormat: 'NUnit'
       testResultsFiles: '$(Build.SourcesDirectory)/Tests/IntegrationTests/**/TestResults/TestResults.xml'
       mergeTestResults: True
@@ -629,7 +629,7 @@ jobs:
     inputs:
       reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
       useFilenameTabs: True
-      tabName: 'Living Doc'
+      tabName: 'Living Doc ($(Agent.OS)-$(Agent.OSArchitecture))'
 
   # Run Sonar analysis.
   - task: SonarCloudAnalyze@3

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -249,7 +249,7 @@ jobs:
       --filter "TestCategory=UnitTests"
       /p:CollectCoverage=true
       /p:CoverletOutputFormat=\"json,cobertura,opencover\"
-      /p:Exclude=\"[Todo.*Tests]*;[Todo.*.TestInfrastructure]*\"
+      /p:Exclude=\"[Todo.*Tests]*,[Todo.*.TestInfrastructure]*\"
       /p:Include=\"[Todo.*]*\"
     name: 'run_unit_tests'
     displayName: 'Run unit tests'
@@ -353,7 +353,7 @@ jobs:
       --filter "TestCategory=IntegrationTests"
       /p:CollectCoverage=true
       /p:CoverletOutputFormat=\"json,cobertura,opencover\"
-      /p:Exclude=\"[Todo.*Tests]*;[Todo.*.TestInfrastructure]*\"
+      /p:Exclude=\"[Todo.*Tests]*,[Todo.*.TestInfrastructure]*\"
       /p:Include=\"[Todo.*]*\"
     name: 'run_integration_tests'
     displayName: 'Run integration tests'

--- a/nuget.config
+++ b/nuget.config
@@ -29,6 +29,11 @@
              protocolVersion="3" />
     </packageSources>
 
+    <disabledPackageSources>
+        <add key="nuget-feed-v2"
+             value="true" />
+    </disabledPackageSources>
+
     <packageSourceMapping>
         <packageSource key="nuget.org">
             <package pattern="*" />


### PR DESCRIPTION
- Fix a bug where code coverage results weren't generated correctly
- Avoid generating code coverage results using multiple formats as `opencover` format is enough since it's used by both `SonarQube Cloud` and `ReportGenerator` tools
- Fine tune code coverage results by using the inclusion and exclusion rules provided by `Coverlet`
- Disable NuGet package source `nuget-feed-v2` which is not used (yet)