### PR TITLE
Publish HTML page storing living doc

### DIFF
--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -604,15 +604,6 @@ jobs:
         --output $(Build.SourcesDirectory)/Tests/AcceptanceTests
         --output-type HTML
 
-  # Publish the HTML document storing living doc.
-  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=blakyaks.azure-pipelines-html-reports.
-  - task: PublishHtmlReport@1
-    displayName: 'Publish living doc'
-    inputs:
-        reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
-        useFilenameTabs: True
-        tabName: 'Living Doc ($(Agent.OS)-$(Agent.OSArchitecture))'
-
   # Publish test related artifacts.
   # See more here: https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-a-pipeline-artifact.
   #

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -629,7 +629,7 @@ jobs:
     inputs:
       reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
       useFilenameTabs: True
-      tabName: 'Living Doc'
+      tabName: 'Living Doc ($(Agent.OS)-$(Agent.OSArchitecture))'
 
   # Run Sonar analysis.
   - task: SonarCloudAnalyze@3

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -623,11 +623,13 @@ jobs:
       path: '$(Build.SourcesDirectory)/Tests'
 
   # Publish the HTML document storing living doc.
-  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=LakshayKaushik.PublishHTMLReports.
-  - task: publishhtmlreport@1
+  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=blakyaks.azure-pipelines-html-reports.
+  - task: PublishHtmlReport@1
+    displayName: 'Publish HTML Report'
     inputs:
-      htmlType: 'genericHTML'
-      htmlPath: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
+      reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
+      useFilenameTabs: True
+      tabName: 'Living Doc'
 
   # Run Sonar analysis.
   - task: SonarCloudAnalyze@3

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -609,9 +609,9 @@ jobs:
   - task: PublishHtmlReport@1
     displayName: 'Publish living doc'
     inputs:
-        reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
-        useFilenameTabs: True
-        tabName: 'Living Doc ($(Agent.OS)-$(Agent.OSArchitecture))'
+      reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
+      useFilenameTabs: True
+      tabName: 'Living Doc ($(Agent.OS)-$(Agent.OSArchitecture))'
 
   # Publish test related artifacts.
   # See more here: https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-a-pipeline-artifact.

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -604,6 +604,15 @@ jobs:
         --output $(Build.SourcesDirectory)/Tests/AcceptanceTests
         --output-type HTML
 
+  # Publish the HTML document storing living doc.
+  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=blakyaks.azure-pipelines-html-reports.
+  - task: PublishHtmlReport@1
+    displayName: 'Publish living doc'
+    inputs:
+        reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
+        useFilenameTabs: True
+        tabName: 'Living Doc ($(Agent.OS)-$(Agent.OSArchitecture))'
+
   # Publish test related artifacts.
   # See more here: https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-a-pipeline-artifact.
   #
@@ -621,15 +630,6 @@ jobs:
     inputs:
       artifact: 'test-artifacts-$(Agent.OS)-$(Agent.OSArchitecture)-$(Build.BuildNumber)-$(Build.BuildID)'
       path: '$(Build.SourcesDirectory)/Tests'
-
-  # Publish the HTML document storing living doc.
-  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=blakyaks.azure-pipelines-html-reports.
-  - task: PublishHtmlReport@1
-    displayName: 'Publish HTML Report'
-    inputs:
-      reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
-      useFilenameTabs: True
-      tabName: 'Living Doc ($(Agent.OS)-$(Agent.OSArchitecture))'
 
   # Run Sonar analysis.
   - task: SonarCloudAnalyze@3

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -622,6 +622,13 @@ jobs:
       artifact: 'test-artifacts-$(Agent.OS)-$(Agent.OSArchitecture)-$(Build.BuildNumber)-$(Build.BuildID)'
       path: '$(Build.SourcesDirectory)/Tests'
 
+  # Publish the HTML document storing living doc.
+  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=LakshayKaushik.PublishHTMLReports.
+  - task: publishhtmlreport@1
+    inputs:
+      htmlType: 'genericHTML'
+      htmlPath: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
+
   # Run Sonar analysis.
   - task: SonarCloudAnalyze@3
     name: 'run_sonar_analysis'

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -604,6 +604,15 @@ jobs:
         --output $(Build.SourcesDirectory)/Tests/AcceptanceTests
         --output-type HTML
 
+  # Publish the HTML document storing living doc.
+  # See more about this Azure DevOps task here: https://marketplace.visualstudio.com/items?itemName=blakyaks.azure-pipelines-html-reports.
+  - task: PublishHtmlReport@1
+    displayName: 'Publish living doc'
+    inputs:
+        reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
+        useFilenameTabs: True
+        tabName: 'Living Doc ($(Agent.OS)-$(Agent.OSArchitecture))'
+
   # Publish test related artifacts.
   # See more here: https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/pipeline-artifacts?view=azure-devops&tabs=yaml#publish-a-pipeline-artifact.
   #

--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -610,7 +610,7 @@ jobs:
     displayName: 'Publish living doc'
     inputs:
       reportDir: '$(Build.SourcesDirectory)/Tests/AcceptanceTests/LivingDoc.html'
-      useFilenameTabs: True
+      useFilenameTabs: False
       tabName: 'Living Doc ($(Agent.OS)-$(Agent.OSArchitecture))'
 
   # Publish test related artifacts.


### PR DESCRIPTION
- Publish HTML page storing living doc via the `Html Reports` Azure DevOps extension
  - Read more about this extension [here](https://marketplace.visualstudio.com/items?itemName=blakyaks.azure-pipelines-html-reports)