### PR TITLE
Fine tune SonarQube Cloud analysis scope configuration

### DIFF
--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -125,8 +125,6 @@ jobs:
       extraProperties: |
         sonar.verbose=${{ parameters.sonar.verbose }}
         sonar.sourceEncoding=${{ parameters.sonar.sourceEncoding }}
-        sonar.sources=$(Build.SourcesDirectory)/Sources/**
-        sonar.tests=$(Build.SourcesDirectory)/Tests/**
         sonar.exclusions=$(Build.SourcesDirectory)/Tests/.CodeCoverageReport/**
         sonar.cs.nunit.reportsPaths=$(Build.SourcesDirectory)/Tests/**/TestResults/TestResults.xml
         sonar.cs.opencover.reportsPaths=$(Build.SourcesDirectory)/Tests/**/coverage.opencover.xml


### PR DESCRIPTION
- Exclude the code coverage report generated by ReportGenerator from
being analyzed by SonarQube Cloud as it would trigger lots of false positives