### PR TITLE
Fix SonarQube Cloud scan paths

### DIFF
--- a/Build/azure-pipelines.job-template.yml
+++ b/Build/azure-pipelines.job-template.yml
@@ -125,9 +125,9 @@ jobs:
       extraProperties: |
         sonar.verbose=${{ parameters.sonar.verbose }}
         sonar.sourceEncoding=${{ parameters.sonar.sourceEncoding }}
-        sonar.exclusions=$(Build.SourcesDirectory)/Tests/.CodeCoverageReport/**
-        sonar.cs.nunit.reportsPaths=$(Build.SourcesDirectory)/Tests/**/TestResults/TestResults.xml
-        sonar.cs.opencover.reportsPaths=$(Build.SourcesDirectory)/Tests/**/coverage.opencover.xml
+        sonar.exclusions=Tests/.CodeCoverageReport/**
+        sonar.cs.nunit.reportsPaths=Tests/**/TestResults/TestResults.xml
+        sonar.cs.opencover.reportsPaths=Tests/**/coverage.opencover.xml
         sonar.analysis.buildNumber=$(Build.BuildId)
         sonar.analysis.pipeline=$(Build.BuildId)
 

--- a/Build/start-docker-on-macOS.sh
+++ b/Build/start-docker-on-macOS.sh
@@ -8,7 +8,7 @@ set -o nounset
 
 # Check for the right Docker Compose version here: https://github.com/docker/compose/releases.
 # Installation steps can be found here: https://docs.docker.com/compose/install/standalone/.
-dockerComposeVersion='2.32.1'
+dockerComposeVersion='2.32.2'
 
 # Check for how to customize Colima VM here: https://github.com/abiosoft/colima?tab=readme-ov-file#customizing-the-vm.
 colimaCpuCount=2

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,10 @@
         <PackageVersion Include="Autofac" Version="8.2.0"/>
         <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0"/>
         <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0"/>
-        <PackageVersion Include="coverlet.msbuild" Version="6.0.2"/>
+        <PackageVersion Include="coverlet.msbuild" Version="6.0.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageVersion>
         <PackageVersion Include="EntityFrameworkCoreMock.Moq" Version="2.4.0"/>
         <PackageVersion Include="FluentAssertions" Version="7.0.0"/>
         <PackageVersion Include="FluentAssertions.Web" Version="1.7.0"/>
@@ -32,7 +35,7 @@
         <PackageVersion Include="Moq" Version="4.20.72"/>
         <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.2"/>
         <PackageVersion Include="NetArchTest.Rules" Version="1.3.2"/>
-        <PackageVersion Include="NUnit" Version="4.3.0"/>
+        <PackageVersion Include="NUnit" Version="4.3.2"/>
         <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0"/>
         <PackageVersion Include="NunitXml.TestLogger" Version="5.0.0"/>
         <PackageVersion Include="OpenTelemetry" Version="1.10.0"/>
@@ -46,13 +49,13 @@
         <PackageVersion Include="Serilog.Enrichers.Span" Version="3.1.0"/>
         <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0"/>
         <PackageVersion Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0"/>
-        <PackageVersion Include="Serilog.Sinks.Seq" Version="8.0.0"/>
+        <PackageVersion Include="Serilog.Sinks.Seq" Version="9.0.0"/>
         <PackageVersion Include="SolidToken.SpecFlow.DependencyInjection" Version="3.9.3"/>
         <PackageVersion Include="SpecFlow.Plus.LivingDocPlugin" Version="3.9.57"/>
         <PackageVersion Include="SpecFlow.xUnit" Version="3.9.74"/>
         <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0"/>
         <PackageVersion Include="Verify.Http" Version="6.4.1"/>
-        <PackageVersion Include="Verify.NUnit" Version="28.6.1"/>
+        <PackageVersion Include="Verify.NUnit" Version="28.8.1"/>
         <PackageVersion Include="xunit" Version="2.9.2"/>
         <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0"/>
         <PackageVersion Include="XunitXml.TestLogger" Version="3.1.20"/>

--- a/Sources/Todo.Telemetry/packages.lock.json
+++ b/Sources/Todo.Telemetry/packages.lock.json
@@ -118,12 +118,12 @@
       },
       "Serilog.Sinks.Seq": {
         "type": "Direct",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "z5ig56/qzjkX6Fj4U/9m1g8HQaQiYPMZS4Uevtjg1I+WWzoGSf5t/E+6JbMP/jbZYhU63bA5NJN5y0x+qqx2Bw==",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "aNU8A0K322q7+voPNmp1/qNPH+9QK8xvM1p72sMmCG0wGlshFzmtDW9QnVSoSYCj0MgQKcMOlgooovtBhRlNHw==",
         "dependencies": {
-          "Serilog": "4.0.0",
-          "Serilog.Sinks.File": "5.0.0"
+          "Serilog": "4.2.0",
+          "Serilog.Sinks.File": "6.0.0"
         }
       },
       "Azure.Core": {

--- a/Sources/Todo.WebApi/packages.lock.json
+++ b/Sources/Todo.WebApi/packages.lock.json
@@ -644,7 +644,7 @@
           "Serilog.Enrichers.Span": "[3.1.0, )",
           "Serilog.Enrichers.Thread": "[4.0.0, )",
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
-          "Serilog.Sinks.Seq": "[8.0.0, )",
+          "Serilog.Sinks.Seq": "[9.0.0, )",
           "Todo.ApplicationFlows": "[1.0.0, )"
         }
       },
@@ -826,12 +826,12 @@
       },
       "Serilog.Sinks.Seq": {
         "type": "CentralTransitive",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "z5ig56/qzjkX6Fj4U/9m1g8HQaQiYPMZS4Uevtjg1I+WWzoGSf5t/E+6JbMP/jbZYhU63bA5NJN5y0x+qqx2Bw==",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "aNU8A0K322q7+voPNmp1/qNPH+9QK8xvM1p72sMmCG0wGlshFzmtDW9QnVSoSYCj0MgQKcMOlgooovtBhRlNHw==",
         "dependencies": {
-          "Serilog": "4.0.0",
-          "Serilog.Sinks.File": "5.0.0"
+          "Serilog": "4.2.0",
+          "Serilog.Sinks.File": "6.0.0"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {

--- a/Tests/ArchitectureTests/Todo.ArchitectureTests/packages.lock.json
+++ b/Tests/ArchitectureTests/Todo.ArchitectureTests/packages.lock.json
@@ -32,9 +32,9 @@
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.3.0, )",
-        "resolved": "4.3.0",
-        "contentHash": "dPClyF8aAmN8w/a7csFXUUbj0sivFVmSfX9CplV+dVeVUqnzoNFsLf7TjAPaxlrwbqHsr+F/pLd7ZEV4Sw9YHg=="
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "puVXayXNmEu7MFQSUswGmUjOy3M3baprMbkLl5PAutpeDoGTr+jPv33qAYsqxywi2wJCq8l/O3EhHoLulPE1iQ=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -731,7 +731,7 @@
           "Serilog.Enrichers.Span": "[3.1.0, )",
           "Serilog.Enrichers.Thread": "[4.0.0, )",
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
-          "Serilog.Sinks.Seq": "[8.0.0, )",
+          "Serilog.Sinks.Seq": "[9.0.0, )",
           "Todo.ApplicationFlows": "[1.0.0, )"
         }
       },
@@ -963,12 +963,12 @@
       },
       "Serilog.Sinks.Seq": {
         "type": "CentralTransitive",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "z5ig56/qzjkX6Fj4U/9m1g8HQaQiYPMZS4Uevtjg1I+WWzoGSf5t/E+6JbMP/jbZYhU63bA5NJN5y0x+qqx2Bw==",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "aNU8A0K322q7+voPNmp1/qNPH+9QK8xvM1p72sMmCG0wGlshFzmtDW9QnVSoSYCj0MgQKcMOlgooovtBhRlNHw==",
         "dependencies": {
-          "Serilog": "4.0.0",
-          "Serilog.Sinks.File": "5.0.0"
+          "Serilog": "4.2.0",
+          "Serilog.Sinks.File": "6.0.0"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {

--- a/Tests/Infrastructure/Todo.WebApi.TestInfrastructure/packages.lock.json
+++ b/Tests/Infrastructure/Todo.WebApi.TestInfrastructure/packages.lock.json
@@ -757,7 +757,7 @@
           "Serilog.Enrichers.Span": "[3.1.0, )",
           "Serilog.Enrichers.Thread": "[4.0.0, )",
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
-          "Serilog.Sinks.Seq": "[8.0.0, )",
+          "Serilog.Sinks.Seq": "[9.0.0, )",
           "Todo.ApplicationFlows": "[1.0.0, )"
         }
       },
@@ -1011,12 +1011,12 @@
       },
       "Serilog.Sinks.Seq": {
         "type": "CentralTransitive",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "z5ig56/qzjkX6Fj4U/9m1g8HQaQiYPMZS4Uevtjg1I+WWzoGSf5t/E+6JbMP/jbZYhU63bA5NJN5y0x+qqx2Bw==",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "aNU8A0K322q7+voPNmp1/qNPH+9QK8xvM1p72sMmCG0wGlshFzmtDW9QnVSoSYCj0MgQKcMOlgooovtBhRlNHw==",
         "dependencies": {
-          "Serilog": "4.0.0",
-          "Serilog.Sinks.File": "5.0.0"
+          "Serilog": "4.2.0",
+          "Serilog.Sinks.File": "6.0.0"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {

--- a/Tests/IntegrationTests/Todo.ApplicationFlows.IntegrationTests/packages.lock.json
+++ b/Tests/IntegrationTests/Todo.ApplicationFlows.IntegrationTests/packages.lock.json
@@ -4,9 +4,9 @@
     "net9.0": {
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "8b4jBNH7mcQy1otyQErjjIUuGD74XxKZ1wvDufbY7jhWwckl7wIa+icjwdPYeI0aYMS4Tp63LIZvyMFjWwOMDw=="
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "QptuqnNCaVlSJcO4lfAPv+9X1Ke+TW216HYD5gSkSb1mbK4K+di1MtsWa3zGCAjnTHDN2TvWVs/Wuw6+mQDhhA=="
       },
       "FluentAssertions": {
         "type": "Direct",
@@ -29,9 +29,9 @@
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.3.0, )",
-        "resolved": "4.3.0",
-        "contentHash": "dPClyF8aAmN8w/a7csFXUUbj0sivFVmSfX9CplV+dVeVUqnzoNFsLf7TjAPaxlrwbqHsr+F/pLd7ZEV4Sw9YHg=="
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "puVXayXNmEu7MFQSUswGmUjOy3M3baprMbkLl5PAutpeDoGTr+jPv33qAYsqxywi2wJCq8l/O3EhHoLulPE1iQ=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -47,16 +47,16 @@
       },
       "Verify.NUnit": {
         "type": "Direct",
-        "requested": "[28.6.1, )",
-        "resolved": "28.6.1",
-        "contentHash": "wGJHxlWFatJNM7jBi23z6Ij+Hurl9dJIZh6cMByasoKAvpZIUqtG/DTnWhIdhNVauKqX4M/UIk6eETfkFtXh6g==",
+        "requested": "[28.8.1, )",
+        "resolved": "28.8.1",
+        "contentHash": "/zWHIPdYWkkueWBc0RyPG5GIv8jpkbslz0sOqBhUOqhuvLD+KshsPndF53ml926cMLi7o93hfvc/oYJwI2+g1g==",
         "dependencies": {
           "Argon": "0.26.0",
           "DiffEngine": "15.6.0",
-          "NUnit": "4.3.0",
+          "NUnit": "4.3.2",
           "SimpleInfoName": "3.1.0",
           "System.IO.Hashing": "9.0.0",
-          "Verify": "28.6.1"
+          "Verify": "28.8.1"
         }
       },
       "Argon": {
@@ -873,8 +873,8 @@
       },
       "Verify": {
         "type": "Transitive",
-        "resolved": "28.6.1",
-        "contentHash": "XvwxRwquFTh4DD8Y2BUuvewIoQh+TT0gwIu9VUBXo5vssYgN748T5x5gwFWG9w4ScLZW1lo4WyqXMq2FQdJeBg==",
+        "resolved": "28.8.1",
+        "contentHash": "lq4wiGgiTYOI6QR38qgY1H+SB4ejSrXReGiFFh5fjh7ZDdJtcEiVMbnReV3MF+4anw+SXmtIXWX6O3/cC4KIow==",
         "dependencies": {
           "Argon": "0.26.0",
           "DiffEngine": "15.6.0",
@@ -927,7 +927,7 @@
           "Serilog.Enrichers.Span": "[3.1.0, )",
           "Serilog.Enrichers.Thread": "[4.0.0, )",
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
-          "Serilog.Sinks.Seq": "[8.0.0, )",
+          "Serilog.Sinks.Seq": "[9.0.0, )",
           "Todo.ApplicationFlows": "[1.0.0, )"
         }
       },
@@ -1199,12 +1199,12 @@
       },
       "Serilog.Sinks.Seq": {
         "type": "CentralTransitive",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "z5ig56/qzjkX6Fj4U/9m1g8HQaQiYPMZS4Uevtjg1I+WWzoGSf5t/E+6JbMP/jbZYhU63bA5NJN5y0x+qqx2Bw==",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "aNU8A0K322q7+voPNmp1/qNPH+9QK8xvM1p72sMmCG0wGlshFzmtDW9QnVSoSYCj0MgQKcMOlgooovtBhRlNHw==",
         "dependencies": {
-          "Serilog": "4.0.0",
-          "Serilog.Sinks.File": "5.0.0"
+          "Serilog": "4.2.0",
+          "Serilog.Sinks.File": "6.0.0"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {

--- a/Tests/IntegrationTests/Todo.Persistence.IntegrationTests/packages.lock.json
+++ b/Tests/IntegrationTests/Todo.Persistence.IntegrationTests/packages.lock.json
@@ -4,9 +4,9 @@
     "net9.0": {
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "8b4jBNH7mcQy1otyQErjjIUuGD74XxKZ1wvDufbY7jhWwckl7wIa+icjwdPYeI0aYMS4Tp63LIZvyMFjWwOMDw=="
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "QptuqnNCaVlSJcO4lfAPv+9X1Ke+TW216HYD5gSkSb1mbK4K+di1MtsWa3zGCAjnTHDN2TvWVs/Wuw6+mQDhhA=="
       },
       "FluentAssertions": {
         "type": "Direct",
@@ -29,9 +29,9 @@
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.3.0, )",
-        "resolved": "4.3.0",
-        "contentHash": "dPClyF8aAmN8w/a7csFXUUbj0sivFVmSfX9CplV+dVeVUqnzoNFsLf7TjAPaxlrwbqHsr+F/pLd7ZEV4Sw9YHg=="
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "puVXayXNmEu7MFQSUswGmUjOy3M3baprMbkLl5PAutpeDoGTr+jPv33qAYsqxywi2wJCq8l/O3EhHoLulPE1iQ=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -723,7 +723,7 @@
           "Serilog.Enrichers.Span": "[3.1.0, )",
           "Serilog.Enrichers.Thread": "[4.0.0, )",
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
-          "Serilog.Sinks.Seq": "[8.0.0, )",
+          "Serilog.Sinks.Seq": "[9.0.0, )",
           "Todo.ApplicationFlows": "[1.0.0, )"
         }
       },
@@ -955,12 +955,12 @@
       },
       "Serilog.Sinks.Seq": {
         "type": "CentralTransitive",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "z5ig56/qzjkX6Fj4U/9m1g8HQaQiYPMZS4Uevtjg1I+WWzoGSf5t/E+6JbMP/jbZYhU63bA5NJN5y0x+qqx2Bw==",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "aNU8A0K322q7+voPNmp1/qNPH+9QK8xvM1p72sMmCG0wGlshFzmtDW9QnVSoSYCj0MgQKcMOlgooovtBhRlNHw==",
         "dependencies": {
-          "Serilog": "4.0.0",
-          "Serilog.Sinks.File": "5.0.0"
+          "Serilog": "4.2.0",
+          "Serilog.Sinks.File": "6.0.0"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {

--- a/Tests/IntegrationTests/Todo.WebApi.IntegrationTests/packages.lock.json
+++ b/Tests/IntegrationTests/Todo.WebApi.IntegrationTests/packages.lock.json
@@ -4,9 +4,9 @@
     "net9.0": {
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "8b4jBNH7mcQy1otyQErjjIUuGD74XxKZ1wvDufbY7jhWwckl7wIa+icjwdPYeI0aYMS4Tp63LIZvyMFjWwOMDw=="
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "QptuqnNCaVlSJcO4lfAPv+9X1Ke+TW216HYD5gSkSb1mbK4K+di1MtsWa3zGCAjnTHDN2TvWVs/Wuw6+mQDhhA=="
       },
       "FluentAssertions": {
         "type": "Direct",
@@ -41,9 +41,9 @@
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.3.0, )",
-        "resolved": "4.3.0",
-        "contentHash": "dPClyF8aAmN8w/a7csFXUUbj0sivFVmSfX9CplV+dVeVUqnzoNFsLf7TjAPaxlrwbqHsr+F/pLd7ZEV4Sw9YHg=="
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "puVXayXNmEu7MFQSUswGmUjOy3M3baprMbkLl5PAutpeDoGTr+jPv33qAYsqxywi2wJCq8l/O3EhHoLulPE1iQ=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -59,16 +59,16 @@
       },
       "Verify.NUnit": {
         "type": "Direct",
-        "requested": "[28.6.1, )",
-        "resolved": "28.6.1",
-        "contentHash": "wGJHxlWFatJNM7jBi23z6Ij+Hurl9dJIZh6cMByasoKAvpZIUqtG/DTnWhIdhNVauKqX4M/UIk6eETfkFtXh6g==",
+        "requested": "[28.8.1, )",
+        "resolved": "28.8.1",
+        "contentHash": "/zWHIPdYWkkueWBc0RyPG5GIv8jpkbslz0sOqBhUOqhuvLD+KshsPndF53ml926cMLi7o93hfvc/oYJwI2+g1g==",
         "dependencies": {
           "Argon": "0.26.0",
           "DiffEngine": "15.6.0",
-          "NUnit": "4.3.0",
+          "NUnit": "4.3.2",
           "SimpleInfoName": "3.1.0",
           "System.IO.Hashing": "9.0.0",
-          "Verify": "28.6.1"
+          "Verify": "28.8.1"
         }
       },
       "Argon": {
@@ -898,8 +898,8 @@
       },
       "Verify": {
         "type": "Transitive",
-        "resolved": "28.6.1",
-        "contentHash": "XvwxRwquFTh4DD8Y2BUuvewIoQh+TT0gwIu9VUBXo5vssYgN748T5x5gwFWG9w4ScLZW1lo4WyqXMq2FQdJeBg==",
+        "resolved": "28.8.1",
+        "contentHash": "lq4wiGgiTYOI6QR38qgY1H+SB4ejSrXReGiFFh5fjh7ZDdJtcEiVMbnReV3MF+4anw+SXmtIXWX6O3/cC4KIow==",
         "dependencies": {
           "Argon": "0.26.0",
           "DiffEngine": "15.6.0",
@@ -952,7 +952,7 @@
           "Serilog.Enrichers.Span": "[3.1.0, )",
           "Serilog.Enrichers.Thread": "[4.0.0, )",
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
-          "Serilog.Sinks.Seq": "[8.0.0, )",
+          "Serilog.Sinks.Seq": "[9.0.0, )",
           "Todo.ApplicationFlows": "[1.0.0, )"
         }
       },
@@ -1224,12 +1224,12 @@
       },
       "Serilog.Sinks.Seq": {
         "type": "CentralTransitive",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "z5ig56/qzjkX6Fj4U/9m1g8HQaQiYPMZS4Uevtjg1I+WWzoGSf5t/E+6JbMP/jbZYhU63bA5NJN5y0x+qqx2Bw==",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "aNU8A0K322q7+voPNmp1/qNPH+9QK8xvM1p72sMmCG0wGlshFzmtDW9QnVSoSYCj0MgQKcMOlgooovtBhRlNHw==",
         "dependencies": {
-          "Serilog": "4.0.0",
-          "Serilog.Sinks.File": "5.0.0"
+          "Serilog": "4.2.0",
+          "Serilog.Sinks.File": "6.0.0"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {

--- a/Tests/UnitTests/Todo.ApplicationFlows.UnitTests/packages.lock.json
+++ b/Tests/UnitTests/Todo.ApplicationFlows.UnitTests/packages.lock.json
@@ -4,9 +4,9 @@
     "net9.0": {
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "8b4jBNH7mcQy1otyQErjjIUuGD74XxKZ1wvDufbY7jhWwckl7wIa+icjwdPYeI0aYMS4Tp63LIZvyMFjWwOMDw=="
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "QptuqnNCaVlSJcO4lfAPv+9X1Ke+TW216HYD5gSkSb1mbK4K+di1MtsWa3zGCAjnTHDN2TvWVs/Wuw6+mQDhhA=="
       },
       "FluentAssertions": {
         "type": "Direct",
@@ -38,9 +38,9 @@
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.3.0, )",
-        "resolved": "4.3.0",
-        "contentHash": "dPClyF8aAmN8w/a7csFXUUbj0sivFVmSfX9CplV+dVeVUqnzoNFsLf7TjAPaxlrwbqHsr+F/pLd7ZEV4Sw9YHg=="
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "puVXayXNmEu7MFQSUswGmUjOy3M3baprMbkLl5PAutpeDoGTr+jPv33qAYsqxywi2wJCq8l/O3EhHoLulPE1iQ=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",

--- a/Tests/UnitTests/Todo.Services.UnitTests/packages.lock.json
+++ b/Tests/UnitTests/Todo.Services.UnitTests/packages.lock.json
@@ -4,9 +4,9 @@
     "net9.0": {
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "8b4jBNH7mcQy1otyQErjjIUuGD74XxKZ1wvDufbY7jhWwckl7wIa+icjwdPYeI0aYMS4Tp63LIZvyMFjWwOMDw=="
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "QptuqnNCaVlSJcO4lfAPv+9X1Ke+TW216HYD5gSkSb1mbK4K+di1MtsWa3zGCAjnTHDN2TvWVs/Wuw6+mQDhhA=="
       },
       "EntityFrameworkCoreMock.Moq": {
         "type": "Direct",
@@ -61,9 +61,9 @@
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.3.0, )",
-        "resolved": "4.3.0",
-        "contentHash": "dPClyF8aAmN8w/a7csFXUUbj0sivFVmSfX9CplV+dVeVUqnzoNFsLf7TjAPaxlrwbqHsr+F/pLd7ZEV4Sw9YHg=="
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "puVXayXNmEu7MFQSUswGmUjOy3M3baprMbkLl5PAutpeDoGTr+jPv33qAYsqxywi2wJCq8l/O3EhHoLulPE1iQ=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -79,16 +79,16 @@
       },
       "Verify.NUnit": {
         "type": "Direct",
-        "requested": "[28.6.1, )",
-        "resolved": "28.6.1",
-        "contentHash": "wGJHxlWFatJNM7jBi23z6Ij+Hurl9dJIZh6cMByasoKAvpZIUqtG/DTnWhIdhNVauKqX4M/UIk6eETfkFtXh6g==",
+        "requested": "[28.8.1, )",
+        "resolved": "28.8.1",
+        "contentHash": "/zWHIPdYWkkueWBc0RyPG5GIv8jpkbslz0sOqBhUOqhuvLD+KshsPndF53ml926cMLi7o93hfvc/oYJwI2+g1g==",
         "dependencies": {
           "Argon": "0.26.0",
           "DiffEngine": "15.6.0",
-          "NUnit": "4.3.0",
+          "NUnit": "4.3.2",
           "SimpleInfoName": "3.1.0",
           "System.IO.Hashing": "9.0.0",
-          "Verify": "28.6.1"
+          "Verify": "28.8.1"
         }
       },
       "Argon": {
@@ -409,8 +409,8 @@
       },
       "Verify": {
         "type": "Transitive",
-        "resolved": "28.6.1",
-        "contentHash": "XvwxRwquFTh4DD8Y2BUuvewIoQh+TT0gwIu9VUBXo5vssYgN748T5x5gwFWG9w4ScLZW1lo4WyqXMq2FQdJeBg==",
+        "resolved": "28.8.1",
+        "contentHash": "lq4wiGgiTYOI6QR38qgY1H+SB4ejSrXReGiFFh5fjh7ZDdJtcEiVMbnReV3MF+4anw+SXmtIXWX6O3/cC4KIow==",
         "dependencies": {
           "Argon": "0.26.0",
           "DiffEngine": "15.6.0",

--- a/Tests/UnitTests/Todo.Telemetry.UnitTests/packages.lock.json
+++ b/Tests/UnitTests/Todo.Telemetry.UnitTests/packages.lock.json
@@ -4,9 +4,9 @@
     "net9.0": {
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "8b4jBNH7mcQy1otyQErjjIUuGD74XxKZ1wvDufbY7jhWwckl7wIa+icjwdPYeI0aYMS4Tp63LIZvyMFjWwOMDw=="
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "QptuqnNCaVlSJcO4lfAPv+9X1Ke+TW216HYD5gSkSb1mbK4K+di1MtsWa3zGCAjnTHDN2TvWVs/Wuw6+mQDhhA=="
       },
       "FluentAssertions": {
         "type": "Direct",
@@ -38,9 +38,9 @@
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.3.0, )",
-        "resolved": "4.3.0",
-        "contentHash": "dPClyF8aAmN8w/a7csFXUUbj0sivFVmSfX9CplV+dVeVUqnzoNFsLf7TjAPaxlrwbqHsr+F/pLd7ZEV4Sw9YHg=="
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "puVXayXNmEu7MFQSUswGmUjOy3M3baprMbkLl5PAutpeDoGTr+jPv33qAYsqxywi2wJCq8l/O3EhHoLulPE1iQ=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -570,7 +570,7 @@
           "Serilog.Enrichers.Span": "[3.1.0, )",
           "Serilog.Enrichers.Thread": "[4.0.0, )",
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
-          "Serilog.Sinks.Seq": "[8.0.0, )",
+          "Serilog.Sinks.Seq": "[9.0.0, )",
           "Todo.ApplicationFlows": "[1.0.0, )"
         }
       },
@@ -752,12 +752,12 @@
       },
       "Serilog.Sinks.Seq": {
         "type": "CentralTransitive",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "z5ig56/qzjkX6Fj4U/9m1g8HQaQiYPMZS4Uevtjg1I+WWzoGSf5t/E+6JbMP/jbZYhU63bA5NJN5y0x+qqx2Bw==",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "aNU8A0K322q7+voPNmp1/qNPH+9QK8xvM1p72sMmCG0wGlshFzmtDW9QnVSoSYCj0MgQKcMOlgooovtBhRlNHw==",
         "dependencies": {
-          "Serilog": "4.0.0",
-          "Serilog.Sinks.File": "5.0.0"
+          "Serilog": "4.2.0",
+          "Serilog.Sinks.File": "6.0.0"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {

--- a/Tests/UnitTests/Todo.WebApi.UnitTests/packages.lock.json
+++ b/Tests/UnitTests/Todo.WebApi.UnitTests/packages.lock.json
@@ -4,9 +4,9 @@
     "net9.0": {
       "coverlet.msbuild": {
         "type": "Direct",
-        "requested": "[6.0.2, )",
-        "resolved": "6.0.2",
-        "contentHash": "8b4jBNH7mcQy1otyQErjjIUuGD74XxKZ1wvDufbY7jhWwckl7wIa+icjwdPYeI0aYMS4Tp63LIZvyMFjWwOMDw=="
+        "requested": "[6.0.3, )",
+        "resolved": "6.0.3",
+        "contentHash": "QptuqnNCaVlSJcO4lfAPv+9X1Ke+TW216HYD5gSkSb1mbK4K+di1MtsWa3zGCAjnTHDN2TvWVs/Wuw6+mQDhhA=="
       },
       "FluentAssertions": {
         "type": "Direct",
@@ -38,9 +38,9 @@
       },
       "NUnit": {
         "type": "Direct",
-        "requested": "[4.3.0, )",
-        "resolved": "4.3.0",
-        "contentHash": "dPClyF8aAmN8w/a7csFXUUbj0sivFVmSfX9CplV+dVeVUqnzoNFsLf7TjAPaxlrwbqHsr+F/pLd7ZEV4Sw9YHg=="
+        "requested": "[4.3.2, )",
+        "resolved": "4.3.2",
+        "contentHash": "puVXayXNmEu7MFQSUswGmUjOy3M3baprMbkLl5PAutpeDoGTr+jPv33qAYsqxywi2wJCq8l/O3EhHoLulPE1iQ=="
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
@@ -56,16 +56,16 @@
       },
       "Verify.NUnit": {
         "type": "Direct",
-        "requested": "[28.6.1, )",
-        "resolved": "28.6.1",
-        "contentHash": "wGJHxlWFatJNM7jBi23z6Ij+Hurl9dJIZh6cMByasoKAvpZIUqtG/DTnWhIdhNVauKqX4M/UIk6eETfkFtXh6g==",
+        "requested": "[28.8.1, )",
+        "resolved": "28.8.1",
+        "contentHash": "/zWHIPdYWkkueWBc0RyPG5GIv8jpkbslz0sOqBhUOqhuvLD+KshsPndF53ml926cMLi7o93hfvc/oYJwI2+g1g==",
         "dependencies": {
           "Argon": "0.26.0",
           "DiffEngine": "15.6.0",
-          "NUnit": "4.3.0",
+          "NUnit": "4.3.2",
           "SimpleInfoName": "3.1.0",
           "System.IO.Hashing": "9.0.0",
-          "Verify": "28.6.1"
+          "Verify": "28.8.1"
         }
       },
       "Argon": {
@@ -753,8 +753,8 @@
       },
       "Verify": {
         "type": "Transitive",
-        "resolved": "28.6.1",
-        "contentHash": "XvwxRwquFTh4DD8Y2BUuvewIoQh+TT0gwIu9VUBXo5vssYgN748T5x5gwFWG9w4ScLZW1lo4WyqXMq2FQdJeBg==",
+        "resolved": "28.8.1",
+        "contentHash": "lq4wiGgiTYOI6QR38qgY1H+SB4ejSrXReGiFFh5fjh7ZDdJtcEiVMbnReV3MF+4anw+SXmtIXWX6O3/cC4KIow==",
         "dependencies": {
           "Argon": "0.26.0",
           "DiffEngine": "15.6.0",
@@ -807,7 +807,7 @@
           "Serilog.Enrichers.Span": "[3.1.0, )",
           "Serilog.Enrichers.Thread": "[4.0.0, )",
           "Serilog.Sinks.ApplicationInsights": "[4.0.0, )",
-          "Serilog.Sinks.Seq": "[8.0.0, )",
+          "Serilog.Sinks.Seq": "[9.0.0, )",
           "Todo.ApplicationFlows": "[1.0.0, )"
         }
       },
@@ -1039,12 +1039,12 @@
       },
       "Serilog.Sinks.Seq": {
         "type": "CentralTransitive",
-        "requested": "[8.0.0, )",
-        "resolved": "8.0.0",
-        "contentHash": "z5ig56/qzjkX6Fj4U/9m1g8HQaQiYPMZS4Uevtjg1I+WWzoGSf5t/E+6JbMP/jbZYhU63bA5NJN5y0x+qqx2Bw==",
+        "requested": "[9.0.0, )",
+        "resolved": "9.0.0",
+        "contentHash": "aNU8A0K322q7+voPNmp1/qNPH+9QK8xvM1p72sMmCG0wGlshFzmtDW9QnVSoSYCj0MgQKcMOlgooovtBhRlNHw==",
         "dependencies": {
-          "Serilog": "4.0.0",
-          "Serilog.Sinks.File": "5.0.0"
+          "Serilog": "4.2.0",
+          "Serilog.Sinks.File": "6.0.0"
         }
       },
       "System.IdentityModel.Tokens.Jwt": {


### PR DESCRIPTION
- Fix SonarQube Cloud scan paths used to identify exclusions, tests and code coverage related files
- Update several NuGet packages to their latest versions
- Update Docker Compose used by macOS-based agent to its latest version